### PR TITLE
Refactor app shell navigation and add directional view transitions

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,21 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
 import { parseISO } from "date-fns";
 import { toast } from "sonner";
 import { Toaster } from "@/components/ui/sonner";
-import { AppSidebar } from "@/components/app-sidebar";
-import DashboardPage from "@/pages/DashboardPage";
+import AppShell from "@/components/app-shell";
 import AuthPage from "@/pages/AuthPage";
 import SetupWizard from "@/pages/SetupWizard";
-import ClientsPage from "@/pages/ClientsPage";
-import InvoicesPage from "@/pages/InvoicesPage";
-import RevenueAdjustmentsPage from "@/pages/RevenueAdjustmentsPage";
-import QuotesPage from "@/pages/QuotesPage";
-import AgreementsPage from "@/pages/AgreementsPage";
-import ProposalsPage from "@/pages/ProposalsPage";
-import ExpensesPage from "@/pages/ExpensesPage";
-import EmailsPage from "@/pages/EmailsPage";
-import SettingsPage from "@/pages/SettingsPage";
-import UsersPage from "@/pages/UsersPage";
 import { api } from "@/api/client";
 import {
   emptyClient,
@@ -41,32 +30,24 @@ import { getAgreementColumns } from "@/columns/agreements.jsx";
 import { getProposalColumns } from "@/columns/proposals.jsx";
 import { getExpenseColumns } from "@/columns/expenses.jsx";
 import { getUserColumns } from "@/columns/users.jsx";
-import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import ViewLoadingFallback from "@/components/view-loading-fallback";
+import { VIEWS, NAV_ITEMS, NAV_GROUPS, buildNavGroups } from "@/navigation/views";
+import useViewNavigation from "@/hooks/useViewNavigation";
+
+const DashboardPage = lazy(() => import("@/pages/DashboardPage"));
+const ClientsPage = lazy(() => import("@/pages/ClientsPage"));
+const InvoicesPage = lazy(() => import("@/pages/InvoicesPage"));
+const RevenueAdjustmentsPage = lazy(() => import("@/pages/RevenueAdjustmentsPage"));
+const QuotesPage = lazy(() => import("@/pages/QuotesPage"));
+const AgreementsPage = lazy(() => import("@/pages/AgreementsPage"));
+const ProposalsPage = lazy(() => import("@/pages/ProposalsPage"));
+const ExpensesPage = lazy(() => import("@/pages/ExpensesPage"));
+const EmailsPage = lazy(() => import("@/pages/EmailsPage"));
+const SettingsPage = lazy(() => import("@/pages/SettingsPage"));
+const UsersPage = lazy(() => import("@/pages/UsersPage"));
 
 export default function App() {
-  const [view, setView] = useState("dashboard");
-  const navigateTo = useCallback(
-    (nextView) => {
-      if (!nextView || nextView === view) return;
-
-      const updateView = () => setView(nextView);
-      const reduceMotion =
-        typeof window !== "undefined" &&
-        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-
-      if (
-        !reduceMotion &&
-        typeof document !== "undefined" &&
-        typeof document.startViewTransition === "function"
-      ) {
-        document.startViewTransition(updateView);
-        return;
-      }
-
-      updateView();
-    },
-    [view]
-  );
+  const { view, navDirection, navigateTo } = useViewNavigation(VIEWS.DASHBOARD);
   const handleLoadError = useCallback(
     (error) => toast.error(error.message || "Unable to load data."),
     []
@@ -181,7 +162,7 @@ export default function App() {
     onCopySuccess: handleEmailCopySuccess,
     onCopyError: handleEmailCopyError,
     onSendSuccess: handleEmailSendSuccess,
-    isActive: view === "emails",
+    isActive: view === VIEWS.EMAILS,
   });
 
   const { updateSettings, saveSettings } = useSettings({
@@ -939,7 +920,7 @@ export default function App() {
       const agreement = agreements.find((item) => item.id === idNum);
       clientId = agreement ? String(agreement.client_id) : "";
     }
-    navigateTo("emails");
+    navigateTo(VIEWS.EMAILS);
     const toEmail = getEntityEmail(entityType, entityId);
     setEmailForm((prev) => ({
       ...prev,
@@ -955,7 +936,7 @@ export default function App() {
   const openCreditNoteForInvoice = useCallback(
     (invoice) => {
       setSelectedAdjustmentInvoiceId(invoice.id);
-      navigateTo("adjustments");
+      navigateTo(VIEWS.ADJUSTMENTS);
       setCreditNoteForm({
         invoice_id: String(invoice.id),
         issued_at: new Date(),
@@ -977,7 +958,7 @@ export default function App() {
 
   const handleViewInvoiceAdjustments = useCallback((invoice) => {
     setSelectedAdjustmentInvoiceId(invoice.id);
-    navigateTo("adjustments");
+    navigateTo(VIEWS.ADJUSTMENTS);
   }, [navigateTo]);
 
   const handleEditCreditNote = useCallback((creditNote) => {
@@ -1225,32 +1206,7 @@ export default function App() {
     [loadAll]
   );
 
-  const navItems = [
-    { id: "dashboard", label: "Dashboard" },
-    { id: "clients", label: "Clients" },
-    { id: "invoices", label: "Invoices" },
-    { id: "quotes", label: "Quotes" },
-    { id: "adjustments", label: "Adjustments" },
-    { id: "agreements", label: "Agreements" },
-    { id: "proposals", label: "Proposals" },
-    { id: "expenses", label: "Expenses" },
-    { id: "emails", label: "Emails" },
-  ];
-
-  const navGroups = [
-    { label: "Overview", items: ["dashboard"] },
-    { label: "Clients", items: ["clients"] },
-    { label: "Revenue", items: ["invoices", "quotes", "adjustments"] },
-    { label: "Agreements", items: ["agreements", "proposals"] },
-    { label: "Operations", items: ["expenses", "emails"] },
-  ]
-    .map((group) => ({
-      label: group.label,
-      items: group.items
-        .map((id) => navItems.find((item) => item.id === id))
-        .filter(Boolean),
-    }))
-    .filter((group) => group.items.length);
+  const navGroups = useMemo(() => buildNavGroups(NAV_ITEMS, NAV_GROUPS), []);
 
   const userMap = useMemo(() => {
     const map = new Map();
@@ -1574,31 +1530,23 @@ export default function App() {
   const canManageSettings = user.role !== "user";
 
   return (
-    <SidebarProvider>
-      <div className="flex w-full min-h-screen bg-background">
-        <Toaster position="top-right" theme="system" richColors />
-        <AppSidebar
-          companyName={settings?.company_name || "Your Company"}
-          navGroups={navGroups}
-          view={view}
-          setView={navigateTo}
-          selectedYear={selectedYear}
-          setSelectedYear={setSelectedYear}
-          financialYears={financialYears}
-          formatFinancialYearLabel={formatFinancialYearLabel}
-          onLogout={logout}
-          showSettings={canManageSettings}
-          showUsers={user?.role === "owner"}
-          userEmail={user?.email}
-        />
-        <SidebarInset>
-          <header className="flex items-center justify-between gap-4 border-b bg-background px-4 py-3 lg:hidden">
-            <SidebarTrigger />
-            <div className="text-sm font-semibold text-foreground">Navigation</div>
-          </header>
-          <main className="w-full space-y-10 px-4 py-8">
-            <div className="app-view-transition">
-        {view === "dashboard" && (
+    <AppShell
+      companyName={settings?.company_name || "Your Company"}
+      navGroups={navGroups}
+      view={view}
+      navigateTo={navigateTo}
+      selectedYear={selectedYear}
+      setSelectedYear={setSelectedYear}
+      financialYears={financialYears}
+      formatFinancialYearLabel={formatFinancialYearLabel}
+      logout={logout}
+      canManageSettings={canManageSettings}
+      isOwner={user?.role === "owner"}
+      userEmail={user?.email}
+    >
+      <div className="app-view-transition" data-nav-direction={navDirection}>
+        <Suspense fallback={<ViewLoadingFallback />}>
+        {view === VIEWS.DASHBOARD && (
           <DashboardPage
             selectedYear={selectedYear}
             financialTotals={financialTotals}
@@ -1611,7 +1559,7 @@ export default function App() {
             formatGBP={formatGBP}
           />
         )}
-        {view === "clients" && (
+        {view === VIEWS.CLIENTS && (
           <ClientsPage
             clients={filteredClients}
             clientColumns={clientColumns}
@@ -1625,7 +1573,7 @@ export default function App() {
             onBulkDelete={handleBulkDeleteClients}
           />
         )}
-        {view === "invoices" && (
+        {view === VIEWS.INVOICES && (
           <InvoicesPage
             invoices={filteredInvoices}
             clients={clients}
@@ -1645,7 +1593,7 @@ export default function App() {
             emptyInvoice={emptyInvoice}
           />
         )}
-        {view === "quotes" && (
+        {view === VIEWS.QUOTES && (
           <QuotesPage
             quotes={filteredQuotes}
             clients={clients}
@@ -1662,7 +1610,7 @@ export default function App() {
             emptyQuote={emptyQuote}
           />
         )}
-        {view === "adjustments" && (
+        {view === VIEWS.ADJUSTMENTS && (
           <RevenueAdjustmentsPage
             creditNotes={creditNotes}
             refunds={refunds}
@@ -1692,7 +1640,7 @@ export default function App() {
             clearInvoiceFilter={() => setSelectedAdjustmentInvoiceId(null)}
           />
         )}
-        {view === "agreements" && (
+        {view === VIEWS.AGREEMENTS && (
           <AgreementsPage
             agreements={filteredAgreements}
             clients={clients}
@@ -1710,7 +1658,7 @@ export default function App() {
             currentUserEmail={user?.email}
           />
         )}
-        {view === "proposals" && (
+        {view === VIEWS.PROPOSALS && (
           <ProposalsPage
             proposals={filteredProposals}
             clients={clients}
@@ -1730,7 +1678,7 @@ export default function App() {
             currentUserEmail={user?.email}
           />
         )}
-        {view === "expenses" && (
+        {view === VIEWS.EXPENSES && (
           <ExpensesPage
             expenses={filteredExpenses}
             clients={clients}
@@ -1747,7 +1695,7 @@ export default function App() {
             onBulkDelete={handleBulkDeleteExpenses}
           />
         )}
-        {view === "emails" && (
+        {view === VIEWS.EMAILS && (
           <EmailsPage
             emailResponse={emailResponse}
             emailDialogOpen={emailDialogOpen}
@@ -1761,7 +1709,7 @@ export default function App() {
             clients={clients}
           />
         )}
-        {view === "settings" && canManageSettings && (
+        {view === VIEWS.SETTINGS && canManageSettings && (
           <SettingsPage
             settings={settings}
             updateSettings={updateSettings}
@@ -1776,7 +1724,7 @@ export default function App() {
             onResetWorkspace={handleResetWorkspace}
           />
         )}
-        {view === "users" && user?.role === "owner" && (
+        {view === VIEWS.USERS && user?.role === "owner" && (
           <UsersPage
             users={users}
             userColumns={userColumns}
@@ -1790,10 +1738,8 @@ export default function App() {
             onBulkDelete={handleBulkDeleteUsers}
           />
         )}
-            </div>
-          </main>
-        </SidebarInset>
+        </Suspense>
       </div>
-    </SidebarProvider>
+    </AppShell>
   );
 }

--- a/frontend/src/components/app-shell.jsx
+++ b/frontend/src/components/app-shell.jsx
@@ -1,0 +1,49 @@
+import { AppSidebar } from "@/components/app-sidebar";
+import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { Toaster } from "@/components/ui/sonner";
+
+export default function AppShell({
+  companyName,
+  navGroups,
+  view,
+  navigateTo,
+  selectedYear,
+  setSelectedYear,
+  financialYears,
+  formatFinancialYearLabel,
+  logout,
+  canManageSettings,
+  isOwner,
+  userEmail,
+  children,
+}) {
+  return (
+    <SidebarProvider>
+      <div className="flex w-full min-h-screen bg-background">
+        <Toaster position="top-right" theme="system" richColors />
+        <AppSidebar
+          companyName={companyName}
+          navGroups={navGroups}
+          view={view}
+          setView={navigateTo}
+          selectedYear={selectedYear}
+          setSelectedYear={setSelectedYear}
+          financialYears={financialYears}
+          formatFinancialYearLabel={formatFinancialYearLabel}
+          onLogout={logout}
+          showSettings={canManageSettings}
+          showUsers={isOwner}
+          userEmail={userEmail}
+        />
+        <SidebarInset>
+          <header className="flex items-center justify-between gap-4 border-b bg-background px-4 py-3 lg:hidden">
+            <SidebarTrigger />
+            <div className="text-sm font-semibold text-foreground">Navigation</div>
+          </header>
+          <main className="w-full space-y-10 px-4 py-8">{children}</main>
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
+  );
+}
+

--- a/frontend/src/components/view-loading-fallback.jsx
+++ b/frontend/src/components/view-loading-fallback.jsx
@@ -1,0 +1,18 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ViewLoadingFallback() {
+  return (
+    <div className="space-y-5">
+      <div className="space-y-3">
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="h-5 w-full max-w-3xl" />
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <Skeleton className="h-48 w-full rounded-3xl" />
+        <Skeleton className="h-48 w-full rounded-3xl" />
+      </div>
+      <Skeleton className="h-64 w-full rounded-3xl" />
+    </div>
+  );
+}
+

--- a/frontend/src/hooks/useViewNavigation.js
+++ b/frontend/src/hooks/useViewNavigation.js
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from "react";
+import { VIEWS, VIEW_ORDER } from "@/navigation/views";
+
+function getDirection(fromView, toView) {
+  const fromIndex = VIEW_ORDER.indexOf(fromView);
+  const toIndex = VIEW_ORDER.indexOf(toView);
+
+  if (fromIndex === -1 || toIndex === -1) return "forward";
+  return toIndex >= fromIndex ? "forward" : "back";
+}
+
+export default function useViewNavigation(initialView = VIEWS.DASHBOARD) {
+  const [view, setView] = useState(initialView);
+  const [navDirection, setNavDirection] = useState("forward");
+
+  const navigateTo = useCallback(
+    (nextView) => {
+      if (!nextView || !VIEW_ORDER.includes(nextView)) {
+        if (import.meta.env.DEV) {
+          console.warn(`[navigation] Ignoring unknown view: ${String(nextView)}`);
+        }
+        return;
+      }
+
+      if (nextView === view) return;
+
+      const direction = getDirection(view, nextView);
+      setNavDirection(direction);
+
+      if (typeof document !== "undefined") {
+        document.documentElement.dataset.navDirection = direction;
+      }
+
+      const updateView = () => setView(nextView);
+      const reduceMotion =
+        typeof window !== "undefined" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+      if (
+        !reduceMotion &&
+        typeof document !== "undefined" &&
+        typeof document.startViewTransition === "function"
+      ) {
+        document.startViewTransition(updateView);
+        return;
+      }
+
+      updateView();
+    },
+    [view]
+  );
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.documentElement.dataset.navDirection = navDirection;
+    }
+  }, [navDirection]);
+
+  return { view, navDirection, navigateTo };
+}
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -99,38 +99,70 @@
 
 ::view-transition-old(app-view),
 ::view-transition-new(app-view) {
-  animation-duration: 220ms;
+  animation-duration: 240ms;
   animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-::view-transition-old(app-view) {
-  animation-name: app-view-fade-out;
-}
-
-::view-transition-new(app-view) {
-  animation-name: app-view-fade-in;
-}
-
-@keyframes app-view-fade-out {
+@keyframes app-view-slide-out-left {
   from {
     opacity: 1;
     transform: translateY(0);
   }
   to {
     opacity: 0;
-    transform: translateY(6px);
+    transform: translateX(-18px);
   }
 }
 
-@keyframes app-view-fade-in {
+@keyframes app-view-slide-in-right {
   from {
     opacity: 0;
-    transform: translateY(-6px);
+    transform: translateX(18px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateX(0);
   }
+}
+
+@keyframes app-view-slide-out-right {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(18px);
+  }
+}
+
+@keyframes app-view-slide-in-left {
+  from {
+    opacity: 0;
+    transform: translateX(-18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+:root[data-nav-direction="back"]::view-transition-old(app-view) {
+  animation-name: app-view-slide-out-right;
+}
+
+:root[data-nav-direction="back"]::view-transition-new(app-view) {
+  animation-name: app-view-slide-in-left;
+}
+
+:root[data-nav-direction="forward"]::view-transition-old(app-view),
+:root:not([data-nav-direction])::view-transition-old(app-view) {
+  animation-name: app-view-slide-out-left;
+}
+
+:root[data-nav-direction="forward"]::view-transition-new(app-view),
+:root:not([data-nav-direction])::view-transition-new(app-view) {
+  animation-name: app-view-slide-in-right;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -29,7 +29,8 @@ function SummaryActionStat({ label, value, onClick }) {
     <button
       type="button"
       onClick={onClick}
-      className="flex w-full items-center justify-between rounded-2xl bg-slate-50/90 px-4 py-3 text-left transition-colors hover:bg-slate-100/90"
+      aria-label={`Open ${label.toLowerCase()}`}
+      className="flex w-full items-center justify-between rounded-2xl bg-slate-50/90 px-4 py-3 text-left transition-colors hover:bg-slate-100/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
     >
       <span className="text-sm text-muted-foreground">{label}</span>
       <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-foreground">
@@ -54,11 +55,13 @@ function MetricTile({ label, value, description, className = "" }) {
   );
 }
 
-function ReminderItem({ icon: Icon, label, value }) {
+function ReminderItem({ icon, label, value }) {
+  const IconComponent = icon;
+
   return (
     <div className="flex items-start gap-3 rounded-2xl bg-slate-50/85 px-4 py-4">
       <div className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-700">
-        <Icon className="h-4 w-4" />
+        <IconComponent className="h-4 w-4" />
       </div>
       <div className="space-y-1">
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
@@ -160,10 +163,10 @@ export default function DashboardPage({
                     Client Management App
                   </div>
                   <div className="space-y-2.5">
-                    <h2 className="whitespace-nowrap text-2xl font-semibold tracking-tight text-foreground sm:text-3xl lg:text-4xl">
+                    <h2 className="text-balance text-2xl font-semibold tracking-tight text-foreground sm:text-3xl lg:text-4xl">
                       Clean financial control, live workload visibility, and less dashboard noise.
                     </h2>
-                    <p className="whitespace-nowrap text-sm leading-7 text-muted-foreground sm:text-base">
+                    <p className="text-pretty text-sm leading-7 text-muted-foreground sm:text-base">
                       {yearLabel}. Track net invoicing, credits, refunds, and the active delivery
                       portfolio from one operational view.
                     </p>


### PR DESCRIPTION
## Summary
- Refactor the authenticated app shell to separate navigation/layout concerns from page orchestration.
- Add app-wide directional React View Transitions with reduced-motion and API fallbacks.
- Improve perceived performance by lazy-loading major views with Suspense loading boundaries.
- Improve dashboard accessibility and responsive hero text wrapping.

## Changes
- App shell/navigation architecture:
  - Added `useViewNavigation` hook for centralized `navigateTo(viewId)` behavior and forward/back direction detection.
  - Added `AppShell` component to own sidebar + authenticated layout container.
  - Wired `App` to use centralized view definitions (`VIEWS`, `NAV_ITEMS`, `NAV_GROUPS`, `buildNavGroups`).

- Lazy loading + loading boundaries:
  - Converted authenticated pages in `App` to `React.lazy(...)`.
  - Wrapped active view rendering in `Suspense`.
  - Added reusable `ViewLoadingFallback` skeleton component.

- View transitions:
  - Added directional transition metadata (`data-nav-direction`) on root.
  - Updated `index.css` view-transition rules for horizontal forward/back animations.
  - Kept reduced-motion handling and fallback when `document.startViewTransition` is unavailable.

- Dashboard UX/accessibility:
  - Updated merged operation stat rows with `aria-label` and visible `focus-visible` rings.
  - Removed forced no-wrap hero text and switched to balanced/pretty wrapping.

## Screenshots (if UI changes)
- Dashboard: responsive hero text wrapping on smaller widths/zoom.
- Dashboard: operations clickable stat rows with subtle focus-visible ring.
- Navigation transitions: forward/back horizontal motion between views.
- Lazy fallback: loading skeleton during first-load of lazy views.

## Checklist
- [x] I have tested these changes locally
- [ ] I have updated documentation where needed
- [x] I have considered migrations or data impacts
