### PR TITLE
Feat/email composer to allow more than 1 entity to be included

### DIFF
--- a/backend/alembic/versions/e3b7f2c9a1d4_add_email_logs.py
+++ b/backend/alembic/versions/e3b7f2c9a1d4_add_email_logs.py
@@ -1,0 +1,56 @@
+"""add email logs
+
+Revision ID: e3b7f2c9a1d4
+Revises: b1c2d3e4f5a6
+Create Date: 2026-04-04 13:20:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "e3b7f2c9a1d4"
+down_revision = "b1c2d3e4f5a6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "email_logs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("group_id", sa.String(length=100), nullable=False),
+        sa.Column("client_id", sa.Integer(), nullable=True),
+        sa.Column("client_label", sa.String(length=200), nullable=False),
+        sa.Column("to_email", sa.String(length=300), nullable=True),
+        sa.Column("subject", sa.Text(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("source", sa.String(length=50), nullable=False),
+        sa.Column("entity_refs", sa.JSON(), nullable=False),
+        sa.Column("attachment_count", sa.Integer(), nullable=False),
+        sa.Column("send_message", sa.Text(), nullable=True),
+        sa.Column("provider_message_id", sa.String(length=255), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("sent_at", sa.DateTime(), nullable=True),
+        sa.Column("delivered_at", sa.DateTime(), nullable=True),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["client_id"], ["clients.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_email_logs_id"), "email_logs", ["id"], unique=False)
+    op.create_index(op.f("ix_email_logs_group_id"), "email_logs", ["group_id"], unique=False)
+    op.create_index(op.f("ix_email_logs_client_id"), "email_logs", ["client_id"], unique=False)
+    op.create_index(op.f("ix_email_logs_status"), "email_logs", ["status"], unique=False)
+    op.create_index(op.f("ix_email_logs_created_at"), "email_logs", ["created_at"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_email_logs_created_at"), table_name="email_logs")
+    op.drop_index(op.f("ix_email_logs_status"), table_name="email_logs")
+    op.drop_index(op.f("ix_email_logs_client_id"), table_name="email_logs")
+    op.drop_index(op.f("ix_email_logs_group_id"), table_name="email_logs")
+    op.drop_index(op.f("ix_email_logs_id"), table_name="email_logs")
+    op.drop_table("email_logs")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from collections import defaultdict
+import mimetypes
 from pathlib import Path
 from uuid import uuid4
 
@@ -8,13 +10,14 @@ from fastapi.responses import JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.background import BackgroundTask
 from sqlalchemy.orm import Session
+from sqlalchemy import inspect
 
 from . import crud, models, schemas
 from .auth import clear_session, create_session, get_current_user, require_role, require_user
 from .config import settings
 from .db import Base, engine, get_db, SessionLocal
 from .email_utils import generate_email_draft, send_email_smtp, test_smtp_connection
-from base64 import b64encode
+from base64 import b64encode, b64decode
 from .security import password_meets_policy, verify_password
 
 
@@ -1340,8 +1343,11 @@ def delete_expense(expense_id: int, db: Session = Depends(get_db)):
 
 
 @app.post("/email/draft", response_model=schemas.EmailDraftResponse)
-
-def create_email_draft(payload: schemas.EmailDraftRequest, db: Session = Depends(get_db)):
+def create_email_draft(
+    payload: schemas.EmailDraftRequest,
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+):
     entity_type = payload.entity_type.lower()
     entity = None
     client = None
@@ -1387,6 +1393,24 @@ def create_email_draft(payload: schemas.EmailDraftRequest, db: Session = Depends
                 }
             )
         sent, message = send_email_smtp(payload.to_email, subject, body, attachments=attachments)
+        status_value = "sent" if sent else "failed"
+        _create_email_log(
+            db,
+            group_id=f"draft-{entity_type}-{entity.id}",
+            client_id=getattr(client, "id", None),
+            client_label=(client.company or client.name) if client else "Unassigned",
+            to_email=payload.to_email,
+            subject=subject,
+            body=body,
+            status=status_value,
+            source="draft",
+            entity_refs=[{"entity_type": entity_type, "entity_id": entity.id}],
+            attachment_count=len(attachments),
+            send_message=message,
+            error_message=message if not sent else None,
+            sent_at=datetime.utcnow() if sent else None,
+            created_by_user_id=user.id,
+        )
         if sent:
             if entity_type == "invoice" and entity.status != "paid":
                 entity.status = "sent"
@@ -1397,6 +1421,10 @@ def create_email_draft(payload: schemas.EmailDraftRequest, db: Session = Depends
             elif entity_type == "proposal" and entity.status == "draft":
                 entity.status = "sent"
                 db.commit()
+            else:
+                db.commit()
+        else:
+            db.commit()
     else:
         sent, message = False, "Draft generated."
 
@@ -1408,3 +1436,477 @@ def create_email_draft(payload: schemas.EmailDraftRequest, db: Session = Depends
         pdf_base64=b64encode(pdf_bytes).decode("utf-8") if pdf_bytes else None,
         pdf_filename=pdf_filename,
     )
+
+
+def _resolve_email_entity(db: Session, entity_type: str, entity_id: int):
+    entity_type = (entity_type or "").lower().strip()
+    entity = None
+    client = None
+
+    if entity_type == "invoice":
+        entity = db.query(models.Invoice).filter(models.Invoice.id == entity_id).first()
+    elif entity_type == "quote":
+        entity = db.query(models.Quote).filter(models.Quote.id == entity_id).first()
+    elif entity_type == "proposal":
+        entity = db.query(models.Proposal).filter(models.Proposal.id == entity_id).first()
+    elif entity_type == "agreement":
+        entity = db.query(models.ServiceAgreement).filter(models.ServiceAgreement.id == entity_id).first()
+    elif entity_type == "expense":
+        entity = db.query(models.Expense).filter(models.Expense.id == entity_id).first()
+    else:
+        raise HTTPException(status_code=400, detail=f"Unsupported entity type: {entity_type}")
+
+    if not entity:
+        raise HTTPException(status_code=404, detail=f"{entity_type.title()} {entity_id} not found")
+
+    client = getattr(entity, "client", None)
+    return entity_type, entity, client
+
+
+def _entity_display_id(entity_type: str, entity):
+    prefixes = {
+        "invoice": "INV",
+        "quote": "QUOTE",
+        "proposal": "PROP",
+        "agreement": "AGR",
+        "expense": "EXP",
+    }
+    return getattr(entity, "display_id", None) or f"{prefixes.get(entity_type, 'DOC')}-{entity.id}"
+
+
+def _load_upload_attachment(file_path: str):
+    if not file_path:
+        return None
+    relative = file_path.replace("\\", "/").lstrip("/")
+    if relative.startswith("uploads/"):
+        relative = relative[len("uploads/"):]
+    candidate = (UPLOADS_DIR / relative).resolve()
+    try:
+        candidate.relative_to(UPLOADS_DIR.resolve())
+    except ValueError:
+        return None
+    if not candidate.exists() or not candidate.is_file():
+        return None
+    return candidate.read_bytes()
+
+
+def _next_unique_filename(filename: str, used_names: set[str]):
+    base_name = (filename or "attachment.pdf").strip() or "attachment.pdf"
+    stem = Path(base_name).stem
+    suffix = Path(base_name).suffix
+    candidate = base_name
+    index = 2
+    while candidate.lower() in used_names:
+        candidate = f"{stem}-{index}{suffix}"
+        index += 1
+    used_names.add(candidate.lower())
+    return candidate
+
+
+def _default_to_email_for_client(client):
+    if not client:
+        return None
+    return client.invoice_email or client.contact_email or client.email
+
+
+def _create_email_log(
+    db: Session,
+    *,
+    group_id: str,
+    client_id: int | None,
+    client_label: str,
+    to_email: str | None,
+    subject: str,
+    body: str,
+    status: str,
+    source: str,
+    entity_refs: list[dict],
+    attachment_count: int,
+    send_message: str | None = None,
+    provider_message_id: str | None = None,
+    error_message: str | None = None,
+    sent_at: datetime | None = None,
+    delivered_at: datetime | None = None,
+    created_by_user_id: int | None = None,
+):
+    if not _email_logs_enabled(db):
+        return None
+    log_row = models.EmailLog(
+        group_id=group_id,
+        client_id=client_id,
+        client_label=client_label,
+        to_email=to_email,
+        subject=subject,
+        body=body,
+        status=status,
+        source=source,
+        entity_refs=entity_refs,
+        attachment_count=attachment_count,
+        send_message=send_message,
+        provider_message_id=provider_message_id,
+        error_message=error_message,
+        sent_at=sent_at,
+        delivered_at=delivered_at,
+        created_by_user_id=created_by_user_id,
+    )
+    db.add(log_row)
+    db.flush()
+    return log_row
+
+
+def _email_logs_enabled(db: Session) -> bool:
+    bind = db.get_bind()
+    if not bind:
+        return False
+    try:
+        return inspect(bind).has_table("email_logs")
+    except Exception:
+        return False
+
+
+@app.post("/email/compose", response_model=schemas.EmailComposeResponse)
+def compose_email(
+    payload: schemas.EmailComposeRequest,
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+):
+    settings_row = crud.get_or_create_settings(db)
+    company_name = settings_row.company_name or "Your Company"
+
+    deduped_items = []
+    seen = set()
+    for item in payload.items:
+        key = (item.entity_type.lower().strip(), int(item.entity_id))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped_items.append(key)
+
+    grouped = defaultdict(list)
+    for entity_type, entity_id in deduped_items:
+        resolved_type, entity, client = _resolve_email_entity(db, entity_type, entity_id)
+        group_key = str(client.id) if client else "unassigned"
+        grouped[group_key].append((resolved_type, entity, client))
+
+    groups_out: list[schemas.EmailComposeGroup] = []
+    sent_groups = 0
+    failed_groups = 0
+    total_attachments = 0
+
+    for group_key, group_items in grouped.items():
+        client = group_items[0][2] if group_items else None
+        client_id = client.id if client else None
+        client_label = (
+            (client.company or client.name) if client else "Unassigned expenses"
+        )
+        to_default = _default_to_email_for_client(client)
+        to_override = payload.to_email_overrides.get(group_key)
+        to_email = to_override if to_override is not None else to_default
+
+        entities_out: list[schemas.EmailComposeEntityOut] = []
+        attachments_out: list[schemas.EmailComposeAttachment] = []
+        used_filenames: set[str] = set()
+        warnings: list[str] = []
+        item_lines: list[str] = []
+        first_subject = ""
+
+        for entity_type, entity, item_client in group_items:
+            subject, _body, pdf_bytes, pdf_filename = generate_email_draft(entity_type, item_client, entity)
+            if not first_subject:
+                first_subject = subject
+
+            display_id = _entity_display_id(entity_type, entity)
+            entities_out.append(
+                schemas.EmailComposeEntityOut(
+                    entity_type=entity_type,
+                    entity_id=entity.id,
+                    display_id=display_id,
+                    title=getattr(entity, "title", None),
+                )
+            )
+            item_lines.append(f"- {display_id} ({entity_type.title()})")
+
+            if pdf_bytes:
+                filename = _next_unique_filename(pdf_filename or f"{display_id}.pdf", used_filenames)
+                attachments_out.append(
+                    schemas.EmailComposeAttachment(
+                        filename=filename,
+                        entity_type=entity_type,
+                        entity_id=entity.id,
+                        source="generated_pdf",
+                        content_base64=b64encode(pdf_bytes).decode("utf-8"),
+                    )
+                )
+
+            if payload.include_proposal_assets and entity_type == "proposal":
+                for attachment in getattr(entity, "attachments", []) or []:
+                    if isinstance(attachment, dict):
+                        file_path = attachment.get("file_path") or ""
+                        attachment_filename = attachment.get("filename")
+                    else:
+                        file_path = getattr(attachment, "file_path", "") or ""
+                        attachment_filename = getattr(attachment, "filename", None)
+                    raw = _load_upload_attachment(file_path)
+                    if raw is None:
+                        warnings.append(
+                            f"Could not load proposal attachment: {attachment_filename or file_path}"
+                        )
+                        continue
+                    candidate_name = (
+                        attachment_filename
+                        or file_path.split("/")[-1]
+                        or f"{display_id}-attachment"
+                    )
+                    filename = _next_unique_filename(candidate_name, used_filenames)
+                    attachments_out.append(
+                        schemas.EmailComposeAttachment(
+                            filename=filename,
+                            entity_type=entity_type,
+                            entity_id=entity.id,
+                            source="proposal_asset",
+                            content_base64=b64encode(raw).decode("utf-8"),
+                        )
+                    )
+
+        if len(group_items) == 1:
+            suggested_subject = first_subject or f"Document update from {company_name}"
+        else:
+            suggested_subject = f"Documents for {client_label} from {company_name}"
+
+        suggested_body = "\n".join(
+            [
+                f"Hi {client_label},",
+                "",
+                "Please find the following documents attached:",
+                *item_lines,
+                "",
+                "Let me know if you have any questions.",
+                "",
+                "Best,",
+                company_name,
+            ]
+        )
+
+        subject = payload.subject_overrides.get(group_key) or suggested_subject
+        body = payload.body_overrides.get(group_key) or suggested_body
+
+        send_result = None
+        if payload.send:
+            if not to_email:
+                warnings.append("No recipient email found for this group.")
+                send_result = schemas.EmailComposeSendResult(
+                    sent=False,
+                    message="Recipient email is required for sending.",
+                )
+                _create_email_log(
+                    db,
+                    group_id=group_key,
+                    client_id=client_id,
+                    client_label=client_label,
+                    to_email=to_email,
+                    subject=subject,
+                    body=body,
+                    status="failed",
+                    source="compose",
+                    entity_refs=[
+                        {"entity_type": entity_type, "entity_id": entity.id}
+                        for entity_type, entity, _ in group_items
+                    ],
+                    attachment_count=len(attachments_out),
+                    send_message="Recipient email is required for sending.",
+                    error_message="Recipient email is required for sending.",
+                    created_by_user_id=user.id,
+                )
+                db.commit()
+                failed_groups += 1
+            else:
+                smtp_attachments = [
+                    {
+                        "content": b"" if not attachment.content_base64 else b64decode(attachment.content_base64),
+                        "filename": attachment.filename,
+                        "maintype": (mimetypes.guess_type(attachment.filename)[0] or "application/octet-stream").split("/")[0],
+                        "subtype": (mimetypes.guess_type(attachment.filename)[0] or "application/octet-stream").split("/")[1],
+                    }
+                    for attachment in attachments_out
+                ]
+                sent, message = send_email_smtp(to_email, subject, body, attachments=smtp_attachments)
+                send_result = schemas.EmailComposeSendResult(
+                    sent=sent,
+                    message=message,
+                    sent_at=datetime.now(timezone.utc) if sent else None,
+                )
+                _create_email_log(
+                    db,
+                    group_id=group_key,
+                    client_id=client_id,
+                    client_label=client_label,
+                    to_email=to_email,
+                    subject=subject,
+                    body=body,
+                    status="sent" if sent else "failed",
+                    source="compose",
+                    entity_refs=[
+                        {"entity_type": entity_type, "entity_id": entity.id}
+                        for entity_type, entity, _ in group_items
+                    ],
+                    attachment_count=len(attachments_out),
+                    send_message=message,
+                    error_message=message if not sent else None,
+                    sent_at=datetime.now(timezone.utc) if sent else None,
+                    created_by_user_id=user.id,
+                )
+                if sent:
+                    sent_groups += 1
+                    for entity_type, entity, _ in group_items:
+                        if entity_type == "invoice" and getattr(entity, "status", None) != "paid":
+                            entity.status = "sent"
+                        elif entity_type == "quote" and getattr(entity, "status", None) == "draft":
+                            entity.status = "sent"
+                        elif entity_type == "proposal" and getattr(entity, "status", None) == "draft":
+                            entity.status = "sent"
+                    db.commit()
+                else:
+                    db.commit()
+                    failed_groups += 1
+
+        total_attachments += len(attachments_out)
+        groups_out.append(
+            schemas.EmailComposeGroup(
+                group_id=group_key,
+                client_id=client_id,
+                client_label=client_label,
+                to_email_default=to_default,
+                to_email=to_email,
+                subject=subject,
+                body=body,
+                entities=entities_out,
+                attachments=attachments_out,
+                send_result=send_result,
+                warnings=warnings,
+            )
+        )
+
+    groups_out.sort(key=lambda item: (item.client_label.lower(), item.group_id))
+
+    return schemas.EmailComposeResponse(
+        groups=groups_out,
+        summary=schemas.EmailComposeSummary(
+            total_items=len(deduped_items),
+            total_groups=len(groups_out),
+            total_attachments=total_attachments,
+            sent_groups=sent_groups,
+            failed_groups=failed_groups,
+        ),
+    )
+
+
+@app.get("/email/logs", response_model=list[schemas.EmailLogOut])
+def list_email_logs(db: Session = Depends(get_db), user=Depends(require_user)):
+    if not _email_logs_enabled(db):
+        return []
+    return (
+        db.query(models.EmailLog)
+        .order_by(models.EmailLog.created_at.desc(), models.EmailLog.id.desc())
+        .all()
+    )
+
+
+@app.post("/email/logs/{log_id}/resend", response_model=schemas.EmailComposeResponse)
+def resend_email_log(log_id: int, db: Session = Depends(get_db), user=Depends(require_user)):
+    if not _email_logs_enabled(db):
+        raise HTTPException(status_code=400, detail="Email logs are not initialized. Run migrations.")
+    log_row = db.query(models.EmailLog).filter(models.EmailLog.id == log_id).first()
+    if not log_row:
+        raise HTTPException(status_code=404, detail="Email log not found")
+    if not log_row.entity_refs:
+        raise HTTPException(status_code=400, detail="Log does not include entities to resend.")
+
+    payload = schemas.EmailComposeRequest(
+        items=[
+            schemas.EmailComposeItem(
+                entity_type=item.get("entity_type", ""),
+                entity_id=int(item.get("entity_id", 0)),
+            )
+            for item in (log_row.entity_refs or [])
+            if item.get("entity_type") and item.get("entity_id")
+        ],
+        send=True,
+        include_proposal_assets=True,
+        to_email_overrides={log_row.group_id: log_row.to_email} if log_row.to_email else {},
+        subject_overrides={log_row.group_id: log_row.subject},
+        body_overrides={log_row.group_id: log_row.body},
+    )
+    if not payload.items:
+        raise HTTPException(status_code=400, detail="Log does not include valid entities to resend.")
+    return compose_email(payload=payload, db=db, user=user)
+
+
+@app.post("/email/logs/resend/bulk", response_model=schemas.EmailComposeSummary)
+def resend_email_logs_bulk(
+    payload: schemas.EmailLogBulkActionRequest,
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+):
+    if not _email_logs_enabled(db):
+        raise HTTPException(status_code=400, detail="Email logs are not initialized. Run migrations.")
+    sent_groups = 0
+    failed_groups = 0
+    total_attachments = 0
+    total_items = 0
+    total_groups = 0
+
+    for log_id in payload.log_ids:
+        try:
+            response = resend_email_log(log_id=log_id, db=db, user=user)
+            sent_groups += int(response.summary.sent_groups or 0)
+            failed_groups += int(response.summary.failed_groups or 0)
+            total_attachments += int(response.summary.total_attachments or 0)
+            total_items += int(response.summary.total_items or 0)
+            total_groups += int(response.summary.total_groups or 0)
+        except HTTPException:
+            failed_groups += 1
+
+    return schemas.EmailComposeSummary(
+        total_items=total_items,
+        total_groups=total_groups,
+        total_attachments=total_attachments,
+        sent_groups=sent_groups,
+        failed_groups=failed_groups,
+    )
+
+
+@app.post("/email/logs/{log_id}/mark-delivered", response_model=schemas.EmailLogOut)
+def mark_email_log_delivered(log_id: int, db: Session = Depends(get_db), user=Depends(require_user)):
+    if not _email_logs_enabled(db):
+        raise HTTPException(status_code=400, detail="Email logs are not initialized. Run migrations.")
+    log_row = db.query(models.EmailLog).filter(models.EmailLog.id == log_id).first()
+    if not log_row:
+        raise HTTPException(status_code=404, detail="Email log not found")
+    log_row.status = "delivered"
+    log_row.delivered_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(log_row)
+    return log_row
+
+
+@app.post("/email/logs/mark-delivered/bulk", response_model=list[schemas.EmailLogOut])
+def mark_email_logs_delivered_bulk(
+    payload: schemas.EmailLogBulkActionRequest,
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+):
+    if not _email_logs_enabled(db):
+        raise HTTPException(status_code=400, detail="Email logs are not initialized. Run migrations.")
+    logs = (
+        db.query(models.EmailLog)
+        .filter(models.EmailLog.id.in_(payload.log_ids))
+        .all()
+    )
+    now = datetime.now(timezone.utc)
+    for log_row in logs:
+        log_row.status = "delivered"
+        log_row.delivered_at = now
+    db.commit()
+    for log_row in logs:
+        db.refresh(log_row)
+    return logs

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -564,6 +564,36 @@ class ExpenseReceipt(Base):
     expense: Mapped["Expense"] = relationship("Expense", back_populates="receipts")
 
 
+class EmailLog(Base):
+    __tablename__ = "email_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    group_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    client_id: Mapped[int | None] = mapped_column(
+        ForeignKey("clients.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    client_label: Mapped[str] = mapped_column(String(200), nullable=False)
+    to_email: Mapped[str | None] = mapped_column(String(300))
+    subject: Mapped[str] = mapped_column(Text(), nullable=False)
+    body: Mapped[str] = mapped_column(Text(), nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="sent", index=True)
+    source: Mapped[str] = mapped_column(String(50), nullable=False, default="compose")
+    entity_refs: Mapped[list[dict]] = mapped_column(JSON, nullable=False, default=list)
+    attachment_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    send_message: Mapped[str | None] = mapped_column(Text())
+    provider_message_id: Mapped[str | None] = mapped_column(String(255))
+    error_message: Mapped[str | None] = mapped_column(Text())
+    sent_at: Mapped[datetime | None] = mapped_column(DateTime)
+    delivered_at: Mapped[datetime | None] = mapped_column(DateTime)
+    created_by_user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, index=True)
+
+    client: Mapped["Client"] = relationship("Client")
+    created_by: Mapped["User"] = relationship("User")
+
+
 class InvoicePayment(Base):
     __tablename__ = "invoice_payments"
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional, Literal
 
-from pydantic import BaseModel, EmailStr, ConfigDict, field_validator
+from pydantic import BaseModel, EmailStr, ConfigDict, Field, field_validator
 
 
 def _blank_to_none(value):
@@ -632,6 +632,110 @@ class EmailDraftRequest(BaseModel):
         if value == "":
             return None
         return value
+
+
+class EmailComposeItem(BaseModel):
+    entity_type: str
+    entity_id: int
+
+
+class EmailComposeRequest(BaseModel):
+    items: list[EmailComposeItem]
+    to_email_overrides: dict[str, EmailStr | None] = Field(default_factory=dict)
+    subject_overrides: dict[str, str] = Field(default_factory=dict)
+    body_overrides: dict[str, str] = Field(default_factory=dict)
+    send: bool = False
+    include_proposal_assets: bool = True
+
+    @field_validator("items")
+    @classmethod
+    def validate_items(cls, value):
+        if not value:
+            raise ValueError("At least one item is required.")
+        return value
+
+
+class EmailComposeAttachment(BaseModel):
+    filename: str
+    entity_type: str
+    entity_id: int
+    source: str
+    content_base64: Optional[str] = None
+
+
+class EmailComposeEntityOut(BaseModel):
+    entity_type: str
+    entity_id: int
+    display_id: Optional[str] = None
+    title: Optional[str] = None
+
+
+class EmailComposeSendResult(BaseModel):
+    sent: bool
+    message: str
+    sent_at: Optional[datetime] = None
+
+
+class EmailComposeGroup(BaseModel):
+    group_id: str
+    client_id: Optional[int] = None
+    client_label: str
+    to_email_default: Optional[EmailStr] = None
+    to_email: Optional[EmailStr] = None
+    subject: str
+    body: str
+    entities: list[EmailComposeEntityOut]
+    attachments: list[EmailComposeAttachment]
+    send_result: Optional[EmailComposeSendResult] = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class EmailComposeSummary(BaseModel):
+    total_items: int
+    total_groups: int
+    total_attachments: int
+    sent_groups: int = 0
+    failed_groups: int = 0
+
+
+class EmailComposeResponse(BaseModel):
+    groups: list[EmailComposeGroup]
+    summary: EmailComposeSummary
+
+
+class EmailLogOut(BaseModel):
+    id: int
+    group_id: str
+    client_id: Optional[int] = None
+    client_label: str
+    to_email: Optional[EmailStr] = None
+    subject: str
+    body: str
+    status: str
+    source: str
+    entity_refs: list[dict] = Field(default_factory=list)
+    attachment_count: int = 0
+    send_message: Optional[str] = None
+    provider_message_id: Optional[str] = None
+    error_message: Optional[str] = None
+    sent_at: Optional[datetime] = None
+    delivered_at: Optional[datetime] = None
+    created_by_user_id: Optional[int] = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class EmailLogBulkActionRequest(BaseModel):
+    log_ids: list[int]
+
+    @field_validator("log_ids")
+    @classmethod
+    def validate_log_ids(cls, value):
+        unique_ids = sorted({int(item) for item in value if int(item) > 0})
+        if not unique_ids:
+            raise ValueError("At least one log id is required.")
+        return unique_ids
 
 
 class AuthLoginRequest(BaseModel):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,7 +22,6 @@ import useAuth from "@/hooks/useAuth";
 import useSettings from "@/hooks/useSettings";
 import useEmailDraft from "@/hooks/useEmailDraft";
 import useYearFilter from "@/hooks/useYearFilter";
-import useEmailEntities from "@/hooks/useEmailEntities";
 import { getClientColumns } from "@/columns/clients.jsx";
 import { getInvoiceColumns } from "@/columns/invoices.jsx";
 import { getQuoteColumns } from "@/columns/quotes.jsx";
@@ -152,9 +151,13 @@ export default function App() {
     emailForm,
     setEmailForm,
     emailResponse,
+    setEmailResponse,
     emailDialogOpen,
     setEmailDialogOpen,
     handleEmailDraftSubmit,
+    submitCompose,
+    sendGroupViaSmtp,
+    composeState,
     handleCopyEmail,
     buildMailto,
   } = useEmailDraft({
@@ -162,7 +165,6 @@ export default function App() {
     onCopySuccess: handleEmailCopySuccess,
     onCopyError: handleEmailCopyError,
     onSendSuccess: handleEmailSendSuccess,
-    isActive: view === VIEWS.EMAILS,
   });
 
   const { updateSettings, saveSettings } = useSettings({
@@ -905,33 +907,60 @@ export default function App() {
   };
 
   const openEmailForEntity = (entityType, entityId, sendNow = false) => {
+    const normalizedType = String(entityType || "").toLowerCase();
     const idNum = Number(entityId);
-    let clientId = "";
-    if (entityType === "invoice") {
-      const invoice = invoices.find((item) => item.id === idNum);
-      clientId = invoice ? String(invoice.client_id) : "";
-    } else if (entityType === "quote") {
-      const quote = quotes.find((item) => item.id === idNum);
-      clientId = quote ? String(quote.client_id) : "";
-    } else if (entityType === "proposal") {
-      const proposal = proposals.find((item) => item.id === idNum);
-      clientId = proposal ? String(proposal.client_id) : "";
-    } else if (entityType === "agreement") {
-      const agreement = agreements.find((item) => item.id === idNum);
-      clientId = agreement ? String(agreement.client_id) : "";
-    }
     navigateTo(VIEWS.EMAILS);
-    const toEmail = getEntityEmail(entityType, entityId);
+    const toEmail = getEntityEmail(normalizedType, entityId);
     setEmailForm((prev) => ({
       ...prev,
-      entity_type: entityType,
-      entity_id: String(entityId),
-      client_id: clientId,
+      selected_items: [
+        ...(prev.selected_items || []).filter(
+          (item) =>
+            !(
+              item.entity_type === normalizedType &&
+              String(item.entity_id) === String(idNum)
+            )
+        ),
+        { entity_type: normalizedType, entity_id: idNum },
+      ],
+      entity_type: normalizedType,
+      entity_id: String(idNum),
       send: sendNow,
-      to_email: toEmail || "",
+      to_email: "",
+      to_email_overrides: {},
+      subject_overrides: {},
+      body_overrides: {},
+      include_proposal_assets: true,
     }));
+    if (!toEmail) {
+      setEmailDialogOpen(true);
+      return;
+    }
     setEmailDialogOpen(true);
   };
+
+  const openComposeForRows = useCallback(
+    (entityType, rows) => {
+      if (!rows?.length) return;
+      navigateTo(VIEWS.EMAILS);
+      const items = rows.map((row) => ({
+        entity_type: entityType,
+        entity_id: row.id,
+      }));
+      setEmailForm((prev) => ({
+        ...prev,
+        selected_items: items,
+        send: false,
+        to_email: "",
+        to_email_overrides: {},
+        subject_overrides: {},
+        body_overrides: {},
+        include_proposal_assets: true,
+      }));
+      setEmailDialogOpen(true);
+    },
+    [navigateTo, setEmailForm]
+  );
 
   const openCreditNoteForInvoice = useCallback(
     (invoice) => {
@@ -1223,8 +1252,6 @@ export default function App() {
     filteredClients,
     filteredInvoices,
     filteredQuotes,
-    filteredCreditNotes,
-    filteredRefunds,
     filteredAgreements,
     filteredProposals,
     filteredExpenses,
@@ -1242,17 +1269,35 @@ export default function App() {
     settings,
   });
 
-  const emailEntityOptions = useEmailEntities({
-    entityType: emailForm.entity_type,
-    clientId: emailForm.client_id,
+  const composeEntities = useMemo(() => {
+    const toEntry = (entityType, item) => {
+      const client = item.client_id ? clientMap.get(item.client_id) : null;
+      const labelId = item.display_id || `${entityType.toUpperCase()}-${item.id}`;
+      const title = item.title || "";
+      return {
+        entity_type: entityType,
+        entity_id: item.id,
+        client_id: item.client_id || "unassigned",
+        client_label: client?.company || client?.name || "Unassigned",
+        label: `${labelId}${title ? ` · ${title}` : ""}`,
+        status: item.status || "",
+      };
+    };
+    return [
+      ...filteredInvoices.map((item) => toEntry("invoice", item)),
+      ...filteredQuotes.map((item) => toEntry("quote", item)),
+      ...filteredProposals.map((item) => toEntry("proposal", item)),
+      ...filteredAgreements.map((item) => toEntry("agreement", item)),
+      ...filteredExpenses.map((item) => toEntry("expense", item)),
+    ];
+  }, [
     clientMap,
-    filteredInvoices,
-    filteredQuotes,
-    filteredCreditNotes,
-    filteredRefunds,
     filteredAgreements,
+    filteredExpenses,
+    filteredInvoices,
     filteredProposals,
-  });
+    filteredQuotes,
+  ]);
 
   const clientColumns = useMemo(
     () =>
@@ -1586,10 +1631,10 @@ export default function App() {
             editingInvoiceId={editingInvoiceId}
             resetInvoiceForm={resetInvoiceForm}
             handleInvoiceSubmit={handleInvoiceSubmit}
-            handleMarkInvoicePaid={handleMarkInvoicePaid}
             onBulkMarkPaid={handleBulkMarkInvoicesPaid}
             onBulkDelete={handleBulkDeleteInvoices}
             onBulkSendReminder={handleBulkSendInvoiceReminders}
+            onBulkCompose={(rows) => openComposeForRows("invoice", rows)}
             emptyInvoice={emptyInvoice}
           />
         )}
@@ -1607,6 +1652,7 @@ export default function App() {
             handleQuoteSubmit={handleQuoteSubmit}
             onBulkDelete={handleBulkDeleteQuotes}
             onBulkSendReminder={handleBulkSendQuoteReminders}
+            onBulkCompose={(rows) => openComposeForRows("quote", rows)}
             emptyQuote={emptyQuote}
           />
         )}
@@ -1654,6 +1700,7 @@ export default function App() {
             resetAgreementForm={resetAgreementForm}
             handleAgreementSubmit={handleAgreementSubmit}
             onBulkDelete={handleBulkDeleteAgreements}
+            onBulkCompose={(rows) => openComposeForRows("agreement", rows)}
             onReload={loadAll}
             currentUserEmail={user?.email}
           />
@@ -1674,6 +1721,7 @@ export default function App() {
             handleProposalUpload={handleProposalUpload}
             onBulkDelete={handleBulkDeleteProposals}
             onBulkSendReminder={handleBulkSendProposalReminders}
+            onBulkCompose={(rows) => openComposeForRows("proposal", rows)}
             onReload={loadAll}
             currentUserEmail={user?.email}
           />
@@ -1693,19 +1741,24 @@ export default function App() {
             handleExpenseSubmit={handleExpenseSubmit}
             handleExpenseUpload={handleExpenseUpload}
             onBulkDelete={handleBulkDeleteExpenses}
+            onBulkCompose={(rows) => openComposeForRows("expense", rows)}
           />
         )}
         {view === VIEWS.EMAILS && (
           <EmailsPage
             emailResponse={emailResponse}
+            setEmailResponse={setEmailResponse}
             emailDialogOpen={emailDialogOpen}
             setEmailDialogOpen={setEmailDialogOpen}
             emailForm={emailForm}
             setEmailForm={setEmailForm}
             handleEmailDraftSubmit={handleEmailDraftSubmit}
+            submitCompose={submitCompose}
+            sendGroupViaSmtp={sendGroupViaSmtp}
+            composeState={composeState}
             handleCopyEmail={handleCopyEmail}
             buildMailto={buildMailto}
-            emailEntityOptions={emailEntityOptions}
+            composeEntities={composeEntities}
             clients={clients}
           />
         )}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -184,6 +184,23 @@ const api = {
   deleteExpense: (id) => request(`/expenses/${id}`, { method: "DELETE" }),
   draftEmail: (payload) =>
     request("/email/draft", { method: "POST", body: JSON.stringify(payload) }),
+  composeEmail: (payload) =>
+    request("/email/compose", { method: "POST", body: JSON.stringify(payload) }),
+  listEmailLogs: () => request("/email/logs"),
+  resendEmailLog: (id) =>
+    request(`/email/logs/${id}/resend`, { method: "POST" }),
+  resendEmailLogsBulk: (logIds) =>
+    request("/email/logs/resend/bulk", {
+      method: "POST",
+      body: JSON.stringify({ log_ids: logIds }),
+    }),
+  markEmailLogDelivered: (id) =>
+    request(`/email/logs/${id}/mark-delivered`, { method: "POST" }),
+  markEmailLogsDeliveredBulk: (logIds) =>
+    request("/email/logs/mark-delivered/bulk", {
+      method: "POST",
+      body: JSON.stringify({ log_ids: logIds }),
+    }),
   createBackup: async ({ download = true, store = true } = {}) => {
     if (download) {
       const response = await fetch(`${API_URL}/admin/backup`, {

--- a/frontend/src/constants/defaults.js
+++ b/frontend/src/constants/defaults.js
@@ -116,7 +116,12 @@ const emptyEmailDraft = {
   entity_type: "invoice",
   entity_id: "",
   client_id: "",
+  selected_items: [],
   to_email: "",
+  to_email_overrides: {},
+  subject_overrides: {},
+  body_overrides: {},
+  include_proposal_assets: true,
   send: false,
 };
 

--- a/frontend/src/hooks/useEmailDraft.js
+++ b/frontend/src/hooks/useEmailDraft.js
@@ -1,62 +1,168 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { api } from "@/api/client";
 import { emptyEmailDraft } from "@/constants/defaults";
 
-const useEmailDraft = ({ onError, onCopySuccess, onCopyError, onSendSuccess, isActive } = {}) => {
-  const [emailForm, setEmailForm] = useState(emptyEmailDraft);
+const useEmailDraft = ({ onError, onCopySuccess, onCopyError, onSendSuccess } = {}) => {
+  const [emailForm, setEmailFormState] = useState(emptyEmailDraft);
   const [emailResponse, setEmailResponse] = useState(null);
   const [emailDialogOpen, setEmailDialogOpen] = useState(false);
+  const [composeState, setComposeState] = useState({
+    isSubmitting: false,
+    action: null,
+    groupId: null,
+  });
+  const composeCacheRef = useRef(new Map());
 
-  useEffect(() => {
+  const setEmailForm = useCallback((next) => {
     setEmailResponse(null);
-  }, [emailForm.entity_type, emailForm.entity_id]);
-
-  useEffect(() => {
-    if (!isActive && emailResponse) {
-      setEmailResponse(null);
+    if (typeof next === "function") {
+      setEmailFormState((prev) => next(prev));
+      return;
     }
-  }, [emailResponse, isActive]);
+    setEmailFormState(next);
+  }, []);
+
+  const submitCompose = useCallback(
+    async (sendOverride = null, options = {}) => {
+      const selectedItemsOverride = options.selectedItems || null;
+      const toEmailOverrides = options.toEmailOverrides || emailForm.to_email_overrides || {};
+      const subjectOverrides = options.subjectOverrides || emailForm.subject_overrides || {};
+      const bodyOverrides = options.bodyOverrides || emailForm.body_overrides || {};
+      const keepDialogOpen = options.keepDialogOpen === true;
+      const groupId = options.groupId || null;
+      try {
+        const selectedItems =
+          selectedItemsOverride ||
+          (emailForm.selected_items?.length
+            ? emailForm.selected_items.map((item) => ({
+                entity_type: item.entity_type,
+                entity_id: Number(item.entity_id),
+              }))
+            : emailForm.entity_id
+              ? [{ entity_type: emailForm.entity_type, entity_id: Number(emailForm.entity_id) }]
+              : []);
+
+        const payload = {
+          items: selectedItems,
+          to_email_overrides: toEmailOverrides,
+          subject_overrides: subjectOverrides,
+          body_overrides: bodyOverrides,
+          include_proposal_assets: emailForm.include_proposal_assets !== false,
+          send: sendOverride ?? emailForm.send,
+        };
+        setComposeState({
+          isSubmitting: true,
+          action: payload.send ? "send" : "generate",
+          groupId,
+        });
+        const cacheKey =
+          payload.send
+            ? null
+            : JSON.stringify({
+                items: payload.items,
+                to_email_overrides: payload.to_email_overrides,
+                subject_overrides: payload.subject_overrides,
+                body_overrides: payload.body_overrides,
+                include_proposal_assets: payload.include_proposal_assets,
+              });
+        const cached = cacheKey ? composeCacheRef.current.get(cacheKey) : null;
+        const response = cached || (await api.composeEmail(payload));
+        if (cacheKey && !cached) {
+          composeCacheRef.current.set(cacheKey, response);
+        }
+        setEmailResponse(response);
+        if (payload.send && onSendSuccess) {
+          const sent = Number(response?.summary?.sent_groups || 0);
+          const failed = Number(response?.summary?.failed_groups || 0);
+          if (failed > 0) {
+            onSendSuccess(`Sent ${sent} group${sent === 1 ? "" : "s"}. ${failed} failed.`);
+          } else {
+            onSendSuccess(`Sent ${sent} group${sent === 1 ? "" : "s"}.`);
+          }
+        }
+        if (!keepDialogOpen) {
+          setEmailDialogOpen(false);
+        }
+        return response;
+      } catch (error) {
+        if (onError) onError(error);
+        return null;
+      } finally {
+        setComposeState({
+          isSubmitting: false,
+          action: null,
+          groupId: null,
+        });
+      }
+    },
+    [emailForm, onError, onSendSuccess]
+  );
+
+  const sendGroupViaSmtp = useCallback(
+    async (group) => {
+      if (!group?.group_id || !Array.isArray(group?.entities)) return;
+      const selectedItems = group.entities.map((entity) => ({
+        entity_type: entity.entity_type,
+        entity_id: Number(entity.entity_id),
+      }));
+      const toEmailOverrides = group.to_email ? { [group.group_id]: group.to_email } : {};
+      const subjectOverrides = { [group.group_id]: group.subject || "" };
+      const bodyOverrides = { [group.group_id]: group.body || "" };
+
+      const response = await submitCompose(true, {
+        selectedItems,
+        toEmailOverrides,
+        subjectOverrides,
+        bodyOverrides,
+        keepDialogOpen: true,
+        groupId: group.group_id,
+      });
+
+      if (!response?.groups?.length) return;
+      const nextGroup = response.groups[0];
+      setEmailResponse((prev) => {
+        if (!prev?.groups?.length) return response;
+        const nextGroups = prev.groups.map((item) =>
+          item.group_id === nextGroup.group_id ? nextGroup : item
+        );
+        const nextSummary = {
+          ...(prev.summary || {}),
+          sent_groups: nextGroups.filter((item) => item.send_result?.sent).length,
+          failed_groups: nextGroups.filter(
+            (item) => item.send_result && item.send_result.sent === false
+          ).length,
+        };
+        return { ...prev, groups: nextGroups, summary: nextSummary };
+      });
+    },
+    [submitCompose]
+  );
 
   const handleEmailDraftSubmit = useCallback(
     async (event) => {
       event.preventDefault();
-      try {
-        const payload = {
-          entity_type: emailForm.entity_type,
-          entity_id: Number(emailForm.entity_id || 0),
-          to_email: emailForm.to_email || null,
-          send: emailForm.send,
-        };
-        const response = await api.draftEmail(payload);
-        setEmailResponse(response);
-        if (response?.sent && onSendSuccess) {
-          onSendSuccess(response.message || "Email sent.");
-        }
-        setEmailDialogOpen(false);
-      } catch (error) {
-        if (onError) onError(error);
-      }
+      await submitCompose();
     },
-    [emailForm, onError]
+    [submitCompose]
   );
 
-  const handleCopyEmail = useCallback(async () => {
-    if (!emailResponse) return;
+  const handleCopyEmail = useCallback(async (text) => {
+    if (!text) return;
     try {
-      await navigator.clipboard.writeText(emailResponse.body);
-      if (onCopySuccess) onCopySuccess("Email body copied to clipboard.");
+      await navigator.clipboard.writeText(text);
+      if (onCopySuccess) onCopySuccess("Copied to clipboard.");
     } catch (error) {
       if (onCopyError) onCopyError(error);
     }
-  }, [emailResponse, onCopyError, onCopySuccess]);
+  }, [onCopyError, onCopySuccess]);
 
-  const buildMailto = useCallback(() => {
-    if (!emailResponse) return "#";
-    const subject = encodeURIComponent(emailResponse.subject || "");
-    const body = encodeURIComponent(emailResponse.body || "");
-    const to = encodeURIComponent(emailForm.to_email || "");
+  const buildMailto = useCallback((group) => {
+    if (!group) return "#";
+    const subject = encodeURIComponent(group.subject || "");
+    const body = encodeURIComponent(group.body || "");
+    const to = encodeURIComponent(group.to_email || group.to_email_default || "");
     return `mailto:${to}?subject=${subject}&body=${body}`;
-  }, [emailForm.to_email, emailResponse]);
+  }, []);
 
   return {
     emailForm,
@@ -66,6 +172,9 @@ const useEmailDraft = ({ onError, onCopySuccess, onCopyError, onSendSuccess, isA
     emailDialogOpen,
     setEmailDialogOpen,
     handleEmailDraftSubmit,
+    submitCompose,
+    sendGroupViaSmtp,
+    composeState,
     handleCopyEmail,
     buildMailto,
   };

--- a/frontend/src/pages/AgreementsPage.jsx
+++ b/frontend/src/pages/AgreementsPage.jsx
@@ -30,6 +30,7 @@ export default function AgreementsPage({
   resetAgreementForm,
   handleAgreementSubmit,
   onBulkDelete,
+  onBulkCompose,
   onReload,
   currentUserEmail,
 }) {
@@ -118,6 +119,33 @@ export default function AgreementsPage({
     },
   };
 
+  function normalizeAgreement(form) {
+    return {
+      client_id: form.client_id || "",
+      display_id: (form.display_id || "").trim(),
+      quote_id: form.quote_id || "",
+      title: (form.title || "").trim(),
+      start_date: form.start_date ? form.start_date.toISOString() : null,
+      end_date: form.end_date ? form.end_date.toISOString() : null,
+      scope_of_services: (form.scope_of_services || "").trim(),
+      duration: (form.duration || "").trim(),
+      availability: (form.availability || "").trim(),
+      meetings: (form.meetings || "").trim(),
+      access_requirements: (form.access_requirements || "").trim(),
+      fees_payments: (form.fees_payments || "").trim(),
+      data_protection: (form.data_protection || "").trim(),
+      termination: (form.termination || "").trim(),
+      company_signatory_name: (form.company_signatory_name || "").trim(),
+      company_signatory_title: (form.company_signatory_title || "").trim(),
+      company_signed_date: form.company_signed_date ? form.company_signed_date.toISOString() : null,
+      client_signatory_name: (form.client_signatory_name || "").trim(),
+      sla_items: (form.sla_items || []).map((item) => ({
+        sla: (item.sla || "").trim(),
+        timescale: (item.timescale || "").trim(),
+      })),
+    };
+  }
+
   useEffect(() => {
     if (agreementDialogOpen) {
       setStepIndex(0);
@@ -179,31 +207,6 @@ export default function AgreementsPage({
       toast.error(error.message || "Unable to prefetch comments.");
     }
   };
-
-  const normalizeAgreement = (form) => ({
-    client_id: form.client_id || "",
-    display_id: (form.display_id || "").trim(),
-    quote_id: form.quote_id || "",
-    title: (form.title || "").trim(),
-    start_date: form.start_date ? form.start_date.toISOString() : null,
-    end_date: form.end_date ? form.end_date.toISOString() : null,
-    scope_of_services: (form.scope_of_services || "").trim(),
-    duration: (form.duration || "").trim(),
-    availability: (form.availability || "").trim(),
-    meetings: (form.meetings || "").trim(),
-    access_requirements: (form.access_requirements || "").trim(),
-    fees_payments: (form.fees_payments || "").trim(),
-    data_protection: (form.data_protection || "").trim(),
-    termination: (form.termination || "").trim(),
-    company_signatory_name: (form.company_signatory_name || "").trim(),
-    company_signatory_title: (form.company_signatory_title || "").trim(),
-    company_signed_date: form.company_signed_date ? form.company_signed_date.toISOString() : null,
-    client_signatory_name: (form.client_signatory_name || "").trim(),
-    sla_items: (form.sla_items || []).map((item) => ({
-      sla: (item.sla || "").trim(),
-      timescale: (item.timescale || "").trim(),
-    })),
-  });
 
   const isAgreementDirty = () => {
     if (!editingAgreementId || !initialSnapshot) return true;
@@ -360,6 +363,11 @@ export default function AgreementsPage({
             exportConfig={exportConfig}
             enableRowSelection
             bulkActions={[
+              {
+                label: "Compose from selected",
+                variant: "outline",
+                onClick: (rows) => onBulkCompose?.(rows),
+              },
               {
                 label: "Delete selected",
                 variant: "destructive",

--- a/frontend/src/pages/EmailsPage.jsx
+++ b/frontend/src/pages/EmailsPage.jsx
@@ -1,246 +1,881 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Loader2, MoreHorizontal } from "lucide-react";
+import { DataTable } from "@/components/data-table";
+import { api } from "@/api/client";
+import { formatDateTime } from "@/utils/format";
+import { toast } from "sonner";
 import { gridTwo, fieldClass, labelClass } from "@/ui/formStyles";
-import { API_URL } from "@/api/client";
+
+const PRESET_STORAGE_KEY = "email_compose_presets_v2";
+const DEFAULT_PRESETS = [
+  {
+    name: "Monthly billing pack",
+    entity_types: ["invoice", "agreement"],
+    include_proposal_assets: true,
+  },
+  {
+    name: "Proposal follow-up",
+    entity_types: ["proposal"],
+    include_proposal_assets: true,
+  },
+];
+
+const ENTITY_TYPES = [
+  { value: "invoice", label: "Invoice" },
+  { value: "quote", label: "Quote" },
+  { value: "proposal", label: "Proposal" },
+  { value: "agreement", label: "Agreement" },
+  { value: "expense", label: "Expense" },
+];
+
+function formatStatus(value) {
+  if (!value) return "";
+  return String(value)
+    .trim()
+    .replace(/[_-]+/g, " ")
+    .split(/\s+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function readSavedPresets() {
+  try {
+    const raw = localStorage.getItem(PRESET_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item) => item?.name && Array.isArray(item?.entity_types));
+  } catch {
+    return [];
+  }
+}
+
+function savePresets(presets) {
+  localStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify(presets));
+}
 
 export default function EmailsPage({
   emailResponse,
+  setEmailResponse,
   emailDialogOpen,
   setEmailDialogOpen,
   emailForm,
   setEmailForm,
   handleEmailDraftSubmit,
+  submitCompose,
+  sendGroupViaSmtp,
+  composeState,
   handleCopyEmail,
   buildMailto,
-  emailEntityOptions,
   clients,
+  composeEntities,
 }) {
-  const selectedEntity = emailEntityOptions.items.find((item) => item.id === emailForm.entity_id);
+  const [search, setSearch] = useState("");
+  const [filterClient, setFilterClient] = useState("");
+  const [filterStatus, setFilterStatus] = useState("");
+  const [filterTypes, setFilterTypes] = useState(() => ENTITY_TYPES.map((item) => item.value));
+  const [presetName, setPresetName] = useState("");
+  const [savedPresets, setSavedPresets] = useState(() => readSavedPresets());
+  const [sendAllDialogOpen, setSendAllDialogOpen] = useState(false);
+  const [emailLogs, setEmailLogs] = useState([]);
+  const [logsLoading, setLogsLoading] = useState(false);
+  const [logActionState, setLogActionState] = useState({ action: null, logId: null });
 
-  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const allPresets = useMemo(() => [...DEFAULT_PRESETS, ...savedPresets], [savedPresets]);
 
-  const downloadBlob = async (blob, filename) => {
+  const visibleEntities = useMemo(() => {
+    return composeEntities
+      .filter((item) => (filterClient ? String(item.client_id || "") === String(filterClient) : true))
+      .filter((item) => (filterStatus ? String(item.status || "").toLowerCase() === filterStatus : true))
+      .filter((item) => filterTypes.includes(item.entity_type))
+      .filter((item) => {
+        if (!search.trim()) return true;
+        const haystack = `${item.label} ${item.client_label} ${item.status || ""}`.toLowerCase();
+        return haystack.includes(search.trim().toLowerCase());
+      });
+  }, [composeEntities, filterClient, filterStatus, filterTypes, search]);
+
+  const selectedKeySet = useMemo(
+    () =>
+      new Set(
+        (emailForm.selected_items || []).map((item) => `${item.entity_type}:${String(item.entity_id)}`)
+      ),
+    [emailForm.selected_items]
+  );
+
+  const selectedEntities = useMemo(
+    () =>
+      composeEntities.filter((item) =>
+        selectedKeySet.has(`${item.entity_type}:${String(item.entity_id)}`)
+      ),
+    [composeEntities, selectedKeySet]
+  );
+
+  const uniqueStatuses = useMemo(() => {
+    const values = new Set();
+    composeEntities.forEach((item) => {
+      if (item.status) values.add(String(item.status).toLowerCase());
+    });
+    return Array.from(values).sort();
+  }, [composeEntities]);
+
+  const allVisibleSelected =
+    visibleEntities.length > 0 &&
+    visibleEntities.every((item) =>
+      selectedKeySet.has(`${item.entity_type}:${String(item.entity_id)}`)
+    );
+
+  const toggleSelectedEntity = (entity, checked) => {
+    const key = `${entity.entity_type}:${String(entity.entity_id)}`;
+    const next = checked
+      ? [
+          ...(emailForm.selected_items || []),
+          { entity_type: entity.entity_type, entity_id: entity.entity_id },
+        ]
+      : (emailForm.selected_items || []).filter(
+          (item) => `${item.entity_type}:${String(item.entity_id)}` !== key
+        );
+    setEmailForm({ ...emailForm, selected_items: next });
+  };
+
+  const toggleAllVisible = (checked) => {
+    if (!checked) {
+      const visibleKeys = new Set(
+        visibleEntities.map((item) => `${item.entity_type}:${String(item.entity_id)}`)
+      );
+      const next = (emailForm.selected_items || []).filter(
+        (item) => !visibleKeys.has(`${item.entity_type}:${String(item.entity_id)}`)
+      );
+      setEmailForm({ ...emailForm, selected_items: next });
+      return;
+    }
+    const dedupe = new Map(
+      (emailForm.selected_items || []).map((item) => [
+        `${item.entity_type}:${String(item.entity_id)}`,
+        item,
+      ])
+    );
+    visibleEntities.forEach((item) => {
+      dedupe.set(`${item.entity_type}:${String(item.entity_id)}`, {
+        entity_type: item.entity_type,
+        entity_id: item.entity_id,
+      });
+    });
+    setEmailForm({ ...emailForm, selected_items: Array.from(dedupe.values()) });
+  };
+
+  const applyPreset = (presetNameValue) => {
+    const preset = allPresets.find((item) => item.name === presetNameValue);
+    if (!preset) return;
+    setFilterTypes(preset.entity_types);
+    setEmailForm({
+      ...emailForm,
+      include_proposal_assets: preset.include_proposal_assets !== false,
+    });
+  };
+
+  const handleSavePreset = () => {
+    const name = presetName.trim();
+    if (!name) return;
+    const next = [
+      ...savedPresets.filter((item) => item.name !== name),
+      {
+        name,
+        entity_types: filterTypes,
+        include_proposal_assets: emailForm.include_proposal_assets !== false,
+      },
+    ];
+    setSavedPresets(next);
+    savePresets(next);
+    setPresetName("");
+  };
+
+  const updateGroupField = (group, field, value) => {
+    const mapKey = group.group_id;
+    const overridesKey =
+      field === "to_email"
+        ? "to_email_overrides"
+        : field === "subject"
+          ? "subject_overrides"
+          : "body_overrides";
+    setEmailForm({
+      ...emailForm,
+      [overridesKey]: {
+        ...(emailForm[overridesKey] || {}),
+        [mapKey]: value,
+      },
+    });
+    if (!emailResponse) return;
+    setEmailResponse({
+      ...emailResponse,
+      groups: (emailResponse.groups || []).map((item) =>
+        item.group_id === group.group_id ? { ...item, [field]: value } : item
+      ),
+    });
+  };
+
+  const downloadAttachment = (attachment) => {
+    if (!attachment?.content_base64) return;
+    const bytes = atob(attachment.content_base64);
+    const buffer = Uint8Array.from(bytes, (char) => char.charCodeAt(0));
+    const blob = new Blob([buffer], { type: "application/octet-stream" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = filename;
-    document.body.appendChild(link);
+    link.download = attachment.filename || "attachment";
     link.click();
-    await wait(150);
-    link.remove();
     URL.revokeObjectURL(url);
   };
 
-  const handleDownloadPdf = async () => {
-    if (!emailResponse?.pdf_base64) return;
-    const byteCharacters = atob(emailResponse.pdf_base64);
-    const byteNumbers = Array.from(byteCharacters, (char) => char.charCodeAt(0));
-    const blob = new Blob([new Uint8Array(byteNumbers)], { type: "application/pdf" });
-    await downloadBlob(blob, emailResponse.pdf_filename || "document.pdf");
+  const downloadGroupAttachments = (group) => {
+    (group.attachments || []).forEach(downloadAttachment);
   };
 
-  const downloadEntityAttachments = async () => {
-    const attachments = selectedEntity?.attachments || [];
-    await Promise.all(
-      attachments.map(async (attachment) => {
-        const filePath = attachment.file_path || "";
-        if (!filePath) return;
-        const url = filePath.startsWith("http")
-          ? filePath
-          : `${API_URL}/${filePath.replace(/^\//, "")}`;
-        const response = await fetch(url, { credentials: "include" });
-        if (!response.ok) return;
-        const blob = await response.blob();
-        await downloadBlob(
-          blob,
-          attachment.filename || filePath.split("/").pop() || "attachment"
-        );
-      })
-    );
+  const downloadAllAttachments = () => {
+    (emailResponse?.groups || []).forEach((group) => downloadGroupAttachments(group));
   };
 
-  const handleOpenMailClient = async () => {
-    if (emailResponse?.pdf_base64) {
-      await handleDownloadPdf();
+  const handleOpenMailClient = (group) => {
+    downloadGroupAttachments(group);
+    setTimeout(() => {
+      window.location.href = buildMailto(group);
+    }, 250);
+  };
+
+  const hasGroups = Boolean(emailResponse?.groups?.length);
+  const isSubmitting = Boolean(composeState?.isSubmitting);
+  const isGenerating = isSubmitting && composeState?.action === "generate";
+  const isSending = isSubmitting && composeState?.action === "send";
+  const isLogActionRunning = Boolean(logActionState.action);
+
+  const getStatusVariant = useCallback((status) => {
+    const normalized = String(status || "").toLowerCase();
+    if (normalized === "failed") return "destructive";
+    if (normalized === "delivered") return "secondary";
+    if (normalized === "sent") return "outline";
+    return "outline";
+  }, []);
+
+  const loadEmailLogs = useCallback(async () => {
+    try {
+      setLogsLoading(true);
+      const data = await api.listEmailLogs();
+      setEmailLogs(Array.isArray(data) ? data : []);
+    } catch (error) {
+      toast.error(error.message || "Unable to load email logs.");
+    } finally {
+      setLogsLoading(false);
     }
-    await downloadEntityAttachments();
-    await wait(250);
-    window.location.href = buildMailto();
-  };
+  }, []);
+
+  useEffect(() => {
+    loadEmailLogs();
+  }, [loadEmailLogs]);
+
+  useEffect(() => {
+    if (!emailResponse?.summary) return;
+    if ((emailResponse.summary.sent_groups || 0) > 0 || (emailResponse.summary.failed_groups || 0) > 0) {
+      loadEmailLogs();
+    }
+  }, [emailResponse, loadEmailLogs]);
+
+  const handleResendLog = useCallback(async (logId) => {
+    try {
+      setLogActionState({ action: "resend", logId });
+      await api.resendEmailLog(logId);
+      toast.success("Email resend attempted.");
+      await loadEmailLogs();
+    } catch (error) {
+      toast.error(error.message || "Unable to resend email.");
+    } finally {
+      setLogActionState({ action: null, logId: null });
+    }
+  }, [loadEmailLogs]);
+
+  const handleMarkDelivered = useCallback(async (logId) => {
+    try {
+      setLogActionState({ action: "delivered", logId });
+      await api.markEmailLogDelivered(logId);
+      toast.success("Email marked as delivered.");
+      await loadEmailLogs();
+    } catch (error) {
+      toast.error(error.message || "Unable to mark email as delivered.");
+    } finally {
+      setLogActionState({ action: null, logId: null });
+    }
+  }, [loadEmailLogs]);
+
+  const emailLogColumns = useMemo(
+    () => [
+      {
+        accessorKey: "created_at",
+        header: "Created",
+        cell: ({ row }) => formatDateTime(row.original.created_at),
+      },
+      {
+        accessorKey: "client_label",
+        header: "Client",
+      },
+      {
+        accessorKey: "to_email",
+        header: "Recipient",
+        cell: ({ row }) => row.original.to_email || "—",
+      },
+      {
+        accessorKey: "status",
+        header: "Status",
+        cell: ({ row }) => (
+          <Badge variant={getStatusVariant(row.original.status)}>
+            {formatStatus(row.original.status)}
+          </Badge>
+        ),
+      },
+      {
+        accessorKey: "attachment_count",
+        header: "Attachments",
+      },
+      {
+        accessorKey: "sent_at",
+        header: "Sent",
+        cell: ({ row }) => formatDateTime(row.original.sent_at),
+      },
+      {
+        id: "actions",
+        header: "Actions",
+        cell: ({ row }) => {
+          const log = row.original;
+          const isThisResending =
+            logActionState.action === "resend" && logActionState.logId === log.id;
+          const isThisDelivering =
+            logActionState.action === "delivered" && logActionState.logId === log.id;
+          const normalizedStatus = String(log.status || "").toLowerCase();
+          return (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button type="button" size="icon" variant="ghost" aria-label={`Actions for log ${log.id}`}>
+                  <MoreHorizontal />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  disabled={isLogActionRunning}
+                  onClick={() => handleResendLog(log.id)}
+                >
+                  {isThisResending ? <Loader2 className="size-4 animate-spin" /> : null}
+                  Resend
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={isLogActionRunning || normalizedStatus === "delivered"}
+                  onClick={() => handleMarkDelivered(log.id)}
+                >
+                  {isThisDelivering ? <Loader2 className="size-4 animate-spin" /> : null}
+                  Mark delivered
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          );
+        },
+      },
+    ],
+    [getStatusVariant, handleMarkDelivered, handleResendLog, isLogActionRunning, logActionState]
+  );
+
+  const emailLogBulkActions = useMemo(
+    () => [
+      {
+        label: "Resend selected",
+        onClick: async (rows) => {
+          const ids = rows.map((row) => row.id);
+          if (!ids.length) return;
+          setLogActionState({ action: "bulk-resend", logId: null });
+          try {
+            await api.resendEmailLogsBulk(ids);
+            toast.success(`Resend attempted for ${ids.length} log${ids.length === 1 ? "" : "s"}.`);
+            await loadEmailLogs();
+          } catch (error) {
+            toast.error(error.message || "Unable to resend selected logs.");
+          } finally {
+            setLogActionState({ action: null, logId: null });
+          }
+        },
+        confirm: {
+          title: "Resend selected emails",
+          description: "This will trigger SMTP resend attempts for the selected logs.",
+          confirmLabel: "Resend selected",
+        },
+        disabled: isLogActionRunning,
+      },
+      {
+        label: "Mark selected delivered",
+        onClick: async (rows) => {
+          const ids = rows.map((row) => row.id);
+          if (!ids.length) return;
+          setLogActionState({ action: "bulk-delivered", logId: null });
+          try {
+            await api.markEmailLogsDeliveredBulk(ids);
+            toast.success(`Marked ${ids.length} log${ids.length === 1 ? "" : "s"} as delivered.`);
+            await loadEmailLogs();
+          } catch (error) {
+            toast.error(error.message || "Unable to mark selected logs as delivered.");
+          } finally {
+            setLogActionState({ action: null, logId: null });
+          }
+        },
+        confirm: {
+          title: "Mark selected as delivered",
+          description: "Use this when you have confirmation from your email provider.",
+          confirmLabel: "Mark delivered",
+        },
+        disabled: isLogActionRunning,
+      },
+    ],
+    [isLogActionRunning, loadEmailLogs]
+  );
 
   return (
     <section className="space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
           <h2 className="text-2xl font-semibold text-foreground">Emails</h2>
-          <p className="text-sm text-muted-foreground">Generate drafts or send via SMTP.</p>
+          <p className="text-sm text-muted-foreground">
+            Multi-entity composer grouped by client.
+          </p>
         </div>
-        <Button
-          onClick={() => {
-            setEmailForm({ ...emailForm, entity_id: "", to_email: "", client_id: "" });
-            setEmailDialogOpen(true);
-          }}
-        >
-          New email
-        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          {hasGroups ? (
+            <>
+              <Button type="button" variant="outline" onClick={downloadAllAttachments}>
+                Download all attachments
+              </Button>
+              <Button
+                type="button"
+                disabled={isSubmitting}
+                onClick={() => setSendAllDialogOpen(true)}
+              >
+                {isSending && !composeState?.groupId ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : null}
+                Send all via SMTP
+              </Button>
+            </>
+          ) : null}
+          <Button type="button" disabled={isSubmitting} onClick={() => setEmailDialogOpen(true)}>
+            Compose email
+          </Button>
+        </div>
       </div>
+      {isSubmitting ? (
+        <div className="flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          <span>
+            {isGenerating
+              ? "Generating drafts..."
+              : composeState?.groupId
+                ? "Sending selected draft via SMTP..."
+                : "Sending drafts via SMTP..."}
+          </span>
+        </div>
+      ) : null}
+
       <Card>
         <CardHeader>
-          <CardTitle>Draft output</CardTitle>
-          <CardDescription>Copy into your email client.</CardDescription>
+          <CardTitle>Draft groups</CardTitle>
+          <CardDescription>One draft per client group. Edit before sending.</CardDescription>
         </CardHeader>
-        <CardContent className="space-y-3">
-          {emailResponse ? (
-            <div className="space-y-3 text-sm">
-              <p className="text-muted-foreground">
-                <span className="font-semibold">Subject:</span> {emailResponse.subject}
-              </p>
-              <pre className="whitespace-pre-wrap rounded-md bg-muted/70 p-3 text-xs text-foreground">
-                {emailResponse.body}
-              </pre>
-              <div className="flex flex-wrap gap-2">
-                <Button type="button" variant="secondary" onClick={handleCopyEmail}>
-                  Copy email
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={handleOpenMailClient}
-                >
-                  Open in mail client
-                </Button>
-                {emailResponse.pdf_base64 ? (
-                  <Button type="button" variant="outline" onClick={handleDownloadPdf}>
-                    Download PDF
-                  </Button>
+        <CardContent className="space-y-4">
+          {!hasGroups ? (
+            <p className="text-sm text-muted-foreground">No drafts generated yet.</p>
+          ) : (
+            (emailResponse.groups || []).map((group) => (
+              <div key={group.group_id} className="space-y-3 rounded-xl border p-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">{group.client_label}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {group.entities.length} item{group.entities.length === 1 ? "" : "s"} ·{" "}
+                      {group.attachments.length} attachment{group.attachments.length === 1 ? "" : "s"}
+                    </p>
+                  </div>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button type="button" size="icon" variant="ghost" aria-label={`Actions for ${group.client_label}`}>
+                        <MoreHorizontal />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => handleCopyEmail(group.body)}>
+                        Copy body
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => handleCopyEmail(`Subject: ${group.subject}\n\n${group.body}`)}>
+                        Copy subject + body
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => handleOpenMailClient(group)}>
+                        Open mail client
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => downloadGroupAttachments(group)}>
+                        Download attachments
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        disabled={isSubmitting || !(group.to_email || group.to_email_default)}
+                        onClick={() => sendGroupViaSmtp(group)}
+                      >
+                        {isSending && composeState?.groupId === group.group_id ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : null}
+                        Send via SMTP
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+
+                <div className={gridTwo}>
+                  <div className={fieldClass}>
+                    <label className={labelClass}>To</label>
+                    <Input
+                      type="email"
+                      value={group.to_email || ""}
+                      placeholder={group.to_email_default || "No default recipient"}
+                      onChange={(event) => updateGroupField(group, "to_email", event.target.value)}
+                    />
+                  </div>
+                  <div className={fieldClass}>
+                    <label className={labelClass}>Subject</label>
+                    <Input
+                      value={group.subject || ""}
+                      onChange={(event) => updateGroupField(group, "subject", event.target.value)}
+                    />
+                  </div>
+                </div>
+                <div className={fieldClass}>
+                  <label className={labelClass}>Body</label>
+                  <Textarea
+                    rows={8}
+                    value={group.body || ""}
+                    onChange={(event) => updateGroupField(group, "body", event.target.value)}
+                  />
+                </div>
+                {group.warnings?.length ? (
+                  <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                    {group.warnings.map((item, idx) => (
+                      <p key={`${group.group_id}-warning-${idx}`}>{item}</p>
+                    ))}
+                  </div>
+                ) : null}
+                {group.send_result ? (
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Badge variant={group.send_result.sent ? "secondary" : "destructive"}>
+                      {group.send_result.sent ? "Sent" : "Failed"}
+                    </Badge>
+                    <span>{group.send_result.message}</span>
+                  </div>
                 ) : null}
               </div>
-              <p className="text-xs text-muted-foreground">
-                Opening the mail client will download the generated PDF and any proposal attachments first so you can attach them manually.
-              </p>
-              <p className="text-xs text-muted-foreground">{emailResponse.message}</p>
-            </div>
-          ) : (
-            <p className="text-sm text-muted-foreground">No draft generated yet.</p>
+            ))
           )}
         </CardContent>
       </Card>
 
+      <Card>
+        <CardHeader>
+          <CardTitle>Email audit log</CardTitle>
+          <CardDescription>Track sends, failures, delivery updates, and resend actions.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex items-center justify-end">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={logsLoading || isLogActionRunning}
+              onClick={loadEmailLogs}
+            >
+              {logsLoading ? <Loader2 className="size-4 animate-spin" /> : null}
+              Refresh logs
+            </Button>
+          </div>
+          <DataTable
+            columns={emailLogColumns}
+            data={emailLogs}
+            emptyMessage={logsLoading ? "Loading email logs..." : "No email logs yet."}
+            searchKey="client_label"
+            searchPlaceholder="Search logs by client..."
+            enableRowSelection
+            bulkActions={emailLogBulkActions}
+          />
+        </CardContent>
+      </Card>
+
       <Dialog open={emailDialogOpen} onOpenChange={setEmailDialogOpen}>
-        <DialogContent>
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-6xl">
           <DialogHeader>
-            <DialogTitle>Compose draft</DialogTitle>
-            <DialogDescription>Pick a record and generate an email.</DialogDescription>
+            <DialogTitle>Compose multi-entity email</DialogTitle>
+            <DialogDescription>
+              Select records, generate grouped drafts, then edit and send.
+            </DialogDescription>
           </DialogHeader>
+
           <form className="space-y-4" onSubmit={handleEmailDraftSubmit}>
-            <div className={gridTwo}>
-              <div className={fieldClass}>
-                <label className={labelClass}>Client</label>
-                <Select
-                  value={emailForm.client_id || "all"}
-                  onValueChange={(value) =>
-                    setEmailForm({
-                      ...emailForm,
-                      client_id: value === "all" ? "" : value,
-                      entity_id: "",
-                    })
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="All clients" />
-                  </SelectTrigger>
-                  <SelectContent>
-                  <SelectItem value="all">All clients</SelectItem>
-                    {clients.map((client) => (
-                      <SelectItem key={client.id} value={String(client.id)}>
-                        {client.company || client.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+            <div className="grid gap-4 lg:grid-cols-3">
+              <div className="space-y-3 rounded-xl border p-3">
+                <p className="text-sm font-semibold text-foreground">Filters</p>
+                <div className={fieldClass}>
+                  <label className={labelClass}>Client</label>
+                  <Select
+                    value={filterClient || "all"}
+                    onValueChange={(value) => setFilterClient(value === "all" ? "" : value)}
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="All clients" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All clients</SelectItem>
+                      {clients.map((client) => (
+                        <SelectItem key={client.id} value={String(client.id)}>
+                          {client.company || client.name}
+                        </SelectItem>
+                      ))}
+                      <SelectItem value="unassigned">Unassigned</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className={fieldClass}>
+                  <label className={labelClass}>Status</label>
+                  <Select
+                    value={filterStatus || "all"}
+                    onValueChange={(value) => setFilterStatus(value === "all" ? "" : value)}
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="All statuses" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All statuses</SelectItem>
+                      {uniqueStatuses.map((status) => (
+                        <SelectItem key={status} value={status}>
+                          {formatStatus(status)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className={fieldClass}>
+                  <label className={labelClass}>Search</label>
+                  <Input value={search} onChange={(event) => setSearch(event.target.value)} />
+                </div>
+                <div className="space-y-2">
+                  <label className={labelClass}>Entity types</label>
+                  {ENTITY_TYPES.map((item) => (
+                    <label key={item.value} className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Checkbox
+                        checked={filterTypes.includes(item.value)}
+                        onCheckedChange={(value) => {
+                          const checked = value === true;
+                          const next = checked
+                            ? Array.from(new Set([...filterTypes, item.value]))
+                            : filterTypes.filter((value) => value !== item.value);
+                          setFilterTypes(next.length ? next : [item.value]);
+                        }}
+                      />
+                      {item.label}
+                    </label>
+                  ))}
+                </div>
+                <div className="space-y-2">
+                  <label className={labelClass}>Presets</label>
+                  <Select
+                    onValueChange={(value) => {
+                      if (value === "none") return;
+                      applyPreset(value);
+                    }}
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Apply preset" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">Apply preset</SelectItem>
+                      {allPresets.map((preset) => (
+                        <SelectItem key={preset.name} value={preset.name}>
+                          {preset.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      placeholder="Preset name"
+                      value={presetName}
+                      onChange={(event) => setPresetName(event.target.value)}
+                    />
+                    <Button type="button" variant="outline" onClick={handleSavePreset}>
+                      Save
+                    </Button>
+                  </div>
+                </div>
               </div>
-              <div className={fieldClass}>
-                <label className={labelClass}>Entity type</label>
-                <Select
-                  value={emailForm.entity_type}
-                  onValueChange={(value) =>
-                    setEmailForm({ ...emailForm, entity_type: value, entity_id: "" })
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="invoice">Invoice</SelectItem>
-                    <SelectItem value="quote">Quote</SelectItem>
-                    <SelectItem value="proposal">Proposal</SelectItem>
-                    <SelectItem value="agreement">Service agreement</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className={fieldClass}>
-                <label className={labelClass}>{emailEntityOptions.label}</label>
-                <Select
-                  value={emailForm.entity_id}
-                  onValueChange={(value) => {
-                    const selected = emailEntityOptions.items.find(
-                      (item) => item.id === value
+
+              <div className="space-y-3 rounded-xl border p-3 lg:col-span-2">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-sm font-semibold text-foreground">Entity picker</p>
+                  <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Checkbox
+                      checked={allVisibleSelected}
+                      onCheckedChange={(value) => toggleAllVisible(value === true)}
+                    />
+                    Select all visible ({visibleEntities.length})
+                  </label>
+                </div>
+                <div className="max-h-72 space-y-2 overflow-y-auto">
+                  {visibleEntities.map((item) => {
+                    const key = `${item.entity_type}:${String(item.entity_id)}`;
+                    return (
+                      <label
+                        key={key}
+                        className="flex cursor-pointer items-center gap-2 rounded-md border px-2 py-2 text-sm hover:bg-muted/40"
+                      >
+                        <Checkbox
+                          checked={selectedKeySet.has(key)}
+                          onCheckedChange={(value) => toggleSelectedEntity(item, value === true)}
+                        />
+                        <div className="min-w-0">
+                          <p className="truncate text-foreground">{item.label}</p>
+                          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                            <span className="truncate text-muted-foreground">{item.client_label}</span>
+                            <Badge variant="outline">{formatStatus(item.entity_type)}</Badge>
+                            {item.status ? (
+                              <Badge variant="secondary">{formatStatus(item.status)}</Badge>
+                            ) : null}
+                          </div>
+                        </div>
+                      </label>
                     );
-                    setEmailForm({
-                      ...emailForm,
-                      entity_id: value,
-                      to_email: selected?.email || emailForm.to_email,
-                    });
-                  }}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder={`Select ${emailEntityOptions.label.toLowerCase()}`} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {emailEntityOptions.items.map((item) => (
-                      <SelectItem key={item.id} value={item.id}>
-                        {item.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className={fieldClass}>
-                <label className={labelClass}>To email (optional)</label>
-                <Input
-                  type="email"
-                  value={emailForm.to_email}
-                  onChange={(event) => setEmailForm({ ...emailForm, to_email: event.target.value })}
-                />
-              </div>
-              <div className={fieldClass}>
-                <label className={labelClass}>Send via SMTP</label>
-                <label className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <input
-                    type="checkbox"
-                    checked={emailForm.send}
-                    onChange={(event) =>
-                      setEmailForm({ ...emailForm, send: event.target.checked })
-                    }
-                  />
-                  Send now (requires SMTP configured)
-                </label>
+                  })}
+                  {!visibleEntities.length ? (
+                    <p className="text-xs text-muted-foreground">No entities match your filters.</p>
+                  ) : null}
+                </div>
+                <div className="rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+                  {selectedEntities.length} selected · grouped automatically by client at draft time
+                </div>
+                <div className="space-y-2">
+                  <p className={labelClass}>Options</p>
+                  <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Checkbox
+                      checked={emailForm.include_proposal_assets !== false}
+                      onCheckedChange={(value) =>
+                        setEmailForm({ ...emailForm, include_proposal_assets: value === true })
+                      }
+                    />
+                    Include proposal uploaded assets
+                  </label>
+                  <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Checkbox
+                      checked={emailForm.send}
+                      onCheckedChange={(value) =>
+                        setEmailForm({ ...emailForm, send: value === true })
+                      }
+                    />
+                    Send via SMTP after draft generation
+                  </label>
+                </div>
               </div>
             </div>
+
             <DialogFooter>
               <DialogClose asChild>
                 <Button type="button" variant="outline">
                   Cancel
                 </Button>
               </DialogClose>
-              <Button type="submit">Generate draft</Button>
+              <Button type="submit" disabled={!selectedEntities.length || isSubmitting}>
+                {isGenerating ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    Generating drafts...
+                  </>
+                ) : emailForm.send ? (
+                  "Generate + send"
+                ) : (
+                  "Generate drafts"
+                )}
+              </Button>
             </DialogFooter>
           </form>
         </DialogContent>
       </Dialog>
+
+      <AlertDialog open={sendAllDialogOpen} onOpenChange={setSendAllDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm send all via SMTP</AlertDialogTitle>
+            <AlertDialogDescription>
+              You are about to send one email per draft group.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="max-h-72 space-y-2 overflow-y-auto rounded-md border p-3">
+            {(emailResponse?.groups || []).map((group) => {
+              const recipient = group.to_email || group.to_email_default || "No recipient set";
+              const hasRecipient = Boolean(group.to_email || group.to_email_default);
+              return (
+                <div key={`send-all-preview-${group.group_id}`} className="rounded-md border p-2">
+                  <p className="text-sm font-medium text-foreground">{group.client_label}</p>
+                  <p className="text-xs text-muted-foreground">
+                    To: {recipient}
+                  </p>
+                  <div className="mt-1 flex items-center gap-2 text-xs">
+                    <Badge variant={hasRecipient ? "secondary" : "destructive"}>
+                      {hasRecipient ? "Ready" : "Missing recipient"}
+                    </Badge>
+                    <span className="text-muted-foreground">
+                      {group.entities?.length || 0} item{(group.entities?.length || 0) === 1 ? "" : "s"} ·{" "}
+                      {group.attachments?.length || 0} attachment{(group.attachments?.length || 0) === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isSubmitting}
+              onClick={async () => {
+                await submitCompose(true);
+                setSendAllDialogOpen(false);
+              }}
+            >
+              {isSending && !composeState?.groupId ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : null}
+              Confirm send all
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }

--- a/frontend/src/pages/ExpensesPage.jsx
+++ b/frontend/src/pages/ExpensesPage.jsx
@@ -33,6 +33,7 @@ export default function ExpensesPage({
   handleExpenseSubmit,
   handleExpenseUpload,
   onBulkDelete,
+  onBulkCompose,
 }) {
   const clientMap = new Map(clients.map((client) => [client.id, client]));
   const userMap = new Map(users.map((person) => [person.id, person]));
@@ -160,6 +161,11 @@ export default function ExpensesPage({
             exportConfig={exportConfig}
             enableRowSelection
             bulkActions={[
+              {
+                label: "Compose from selected",
+                variant: "outline",
+                onClick: (rows) => onBulkCompose?.(rows),
+              },
               {
                 label: "Delete selected",
                 variant: "destructive",

--- a/frontend/src/pages/InvoicesPage.jsx
+++ b/frontend/src/pages/InvoicesPage.jsx
@@ -23,10 +23,10 @@ export default function InvoicesPage({
   editingInvoiceId,
   resetInvoiceForm,
   handleInvoiceSubmit,
-  handleMarkInvoicePaid,
   onBulkMarkPaid,
   onBulkDelete,
   onBulkSendReminder,
+  onBulkCompose,
   emptyInvoice,
 }) {
   const [recurringDialogOpen, setRecurringDialogOpen] = useState(false);
@@ -142,6 +142,11 @@ export default function InvoicesPage({
             exportConfig={exportConfig}
             enableRowSelection
             bulkActions={[
+              {
+                label: "Compose from selected",
+                variant: "outline",
+                onClick: (rows) => onBulkCompose?.(rows),
+              },
               {
                 label: "Mark as paid",
                 variant: "outline",

--- a/frontend/src/pages/ProposalsPage.jsx
+++ b/frontend/src/pages/ProposalsPage.jsx
@@ -40,6 +40,7 @@ export default function ProposalsPage({
   handleProposalUpload,
   onBulkDelete,
   onBulkSendReminder,
+  onBulkCompose,
   onReload,
   currentUserEmail,
 }) {
@@ -382,6 +383,11 @@ export default function ProposalsPage({
             exportConfig={exportConfig}
             enableRowSelection
             bulkActions={[
+              {
+                label: "Compose from selected",
+                variant: "outline",
+                onClick: (rows) => onBulkCompose?.(rows),
+              },
               {
                 label: "Send reminders",
                 variant: "outline",

--- a/frontend/src/pages/QuotesPage.jsx
+++ b/frontend/src/pages/QuotesPage.jsx
@@ -22,6 +22,7 @@ export default function QuotesPage({
   handleQuoteSubmit,
   onBulkDelete,
   onBulkSendReminder,
+  onBulkCompose,
   emptyQuote,
 }) {
   const clientMap = new Map(clients.map((client) => [client.id, client]));
@@ -119,6 +120,11 @@ export default function QuotesPage({
             exportConfig={exportConfig}
             enableRowSelection
             bulkActions={[
+              {
+                label: "Compose from selected",
+                variant: "outline",
+                onClick: (rows) => onBulkCompose?.(rows),
+              },
               {
                 label: "Send reminders",
                 variant: "outline",

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -1,5 +1,18 @@
 import { format } from "date-fns";
 
+const hasTimezoneInfo = (raw) => /([zZ]|[+-]\d{2}:\d{2})$/.test(raw);
+
+const parseDate = (value, { assumeUtcIfNaive = false } = {}) => {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  const raw = String(value);
+  const normalized =
+    assumeUtcIfNaive && !hasTimezoneInfo(raw) ? `${raw}Z` : raw;
+  const date = new Date(normalized);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+};
+
 const toDateTime = (dateValue) => {
   if (!dateValue) return null;
   if (dateValue instanceof Date) {
@@ -10,8 +23,8 @@ const toDateTime = (dateValue) => {
 
 const formatDate = (value) => {
   if (!value) return "—";
-  const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) return "—";
+  const date = parseDate(value);
+  if (!date) return "—";
   const day = String(date.getDate()).padStart(2, "0");
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const year = date.getFullYear();
@@ -20,8 +33,8 @@ const formatDate = (value) => {
 
 const formatDateTime = (value) => {
   if (!value) return "—";
-  const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) return "—";
+  const date = parseDate(value, { assumeUtcIfNaive: true });
+  if (!date) return "—";
   const day = String(date.getDate()).padStart(2, "0");
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const year = date.getFullYear();
@@ -32,8 +45,8 @@ const formatDateTime = (value) => {
 
 const toTimestamp = (value) => {
   if (!value) return 0;
-  const date = value instanceof Date ? value : new Date(value);
-  return Number.isNaN(date.getTime()) ? 0 : date.getTime();
+  const date = parseDate(value, { assumeUtcIfNaive: true });
+  return date ? date.getTime() : 0;
 };
 
 const gbpFormatter = new Intl.NumberFormat("en-GB", {


### PR DESCRIPTION
## Summary
This PR upgrades the email composer and audit experience with:
- Multi-entity compose/send stability fixes
- In-app email audit logging
- Per-log and bulk resend/delivery actions
- Improved email compose UX (loading states, send confirmations, action menu consolidation)
- Timezone-safe timestamp display (UTC storage/display conversion fix)

## What Changed

### Backend
- Added `email_logs` persistence:
  - New model: `EmailLog`
  - New migration: `e3b7f2c9a1d4_add_email_logs.py`
- Added schemas:
  - `EmailLogOut`
  - `EmailLogBulkActionRequest`
- Added endpoints:
  - `GET /email/logs`
  - `POST /email/logs/{log_id}/resend`
  - `POST /email/logs/resend/bulk`
  - `POST /email/logs/{log_id}/mark-delivered`
  - `POST /email/logs/mark-delivered/bulk`
- Logged SMTP outcomes from:
  - `POST /email/compose`
  - `POST /email/draft` (legacy single-entity send path)
- Added compatibility guard:
  - If `email_logs` table is not yet migrated, logs endpoints fail gracefully (no 500 crash)
- Fixed proposal attachment handling in `/email/compose` for SQLAlchemy objects (not just dicts).
- Switched send/delivered timestamps in email paths to explicit UTC-aware datetimes.

### Frontend
- Emails page UX improvements:
  - Replaced action button overload with 3-dot action menu per draft group
  - Added per-group `Send via SMTP` action
  - Added shadcn confirmation dialog for `Send all via SMTP` with recipient/group preview
  - Added loading spinners/loading states for generate/send flows
- Implemented Email Audit UI using existing `DataTable`:
  - Status badges/pills with normalized/capitalized status strings
  - Row actions: resend, mark delivered
  - Multi-select + bulk action bar:
    - Resend selected
    - Mark selected delivered
- API client additions for all email log endpoints.
- Fixed datetime rendering:
  - Frontend now treats timezone-naive API datetime strings as UTC before local rendering, ensuring correct user-local time and DST handling.

## Why
- Reduces manual follow-up and re-sending overhead
- Provides in-app auditability for operational traceability
- Improves confidence and feedback during async send/generate operations
- Fixes incorrect displayed send times in local timezone (DST-safe)

## Validation
- Backend compile check passed:
  - `python -m py_compile backend/app/main.py backend/app/models.py backend/app/schemas.py`
- Frontend checks passed:
  - `npx eslint src/pages/EmailsPage.jsx src/hooks/useEmailDraft.js src/utils/format.js`
  - `npm run build`

## Migration
Run before testing/merging:
```bash
cd backend
source .venv/bin/activate
alembic upgrade head
