### PR TITLE
feat(workspaces): add strict multi-workspace tenancy, scoped backups,…

### DIFF
--- a/backend/alembic/versions/a7c3d1f9b2aa_add_workspaces_multitenancy.py
+++ b/backend/alembic/versions/a7c3d1f9b2aa_add_workspaces_multitenancy.py
@@ -1,0 +1,315 @@
+"""add workspaces multitenancy
+
+Revision ID: a7c3d1f9b2aa
+Revises: f4a1c9e7d2b3
+Create Date: 2026-04-04 18:10:00.000000
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import re
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+
+# revision identifiers, used by Alembic.
+revision = "a7c3d1f9b2aa"
+down_revision = "f4a1c9e7d2b3"
+branch_labels = None
+depends_on = None
+
+
+WORKSPACE_TABLES = [
+    "clients",
+    "invoices",
+    "quotes",
+    "invoice_line_items",
+    "quote_line_items",
+    "credit_notes",
+    "credit_note_line_items",
+    "refunds",
+    "service_agreements",
+    "agreement_slas",
+    "agreement_versions",
+    "agreement_version_comments",
+    "agreement_version_comment_reactions",
+    "proposals",
+    "proposal_requirements",
+    "proposal_attachments",
+    "proposal_versions",
+    "proposal_version_comments",
+    "proposal_version_comment_reactions",
+    "expenses",
+    "expense_receipts",
+    "settings",
+    "tax_rate_catalogs",
+    "email_logs",
+    "invoice_payments",
+    "payment_tax_allocations",
+]
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", (value or "").strip().lower()).strip("-")
+    return slug or "workspace"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    op.create_table(
+        "workspaces",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("slug", sa.String(length=200), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+    )
+    op.create_index("ix_workspaces_id", "workspaces", ["id"])
+    op.create_index("ix_workspaces_slug", "workspaces", ["slug"], unique=True)
+
+    op.create_table(
+        "workspace_memberships",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("workspace_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("role", sa.String(length=20), nullable=False, server_default="user"),
+        sa.Column("is_default", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("workspace_id", "user_id", name="uq_workspace_membership"),
+    )
+    op.create_index("ix_workspace_memberships_id", "workspace_memberships", ["id"])
+    op.create_index("ix_workspace_memberships_workspace_id", "workspace_memberships", ["workspace_id"])
+    op.create_index("ix_workspace_memberships_user_id", "workspace_memberships", ["user_id"])
+
+    with op.batch_alter_table("user_sessions") as batch_op:
+        batch_op.add_column(sa.Column("active_workspace_id", sa.Integer(), nullable=True))
+        batch_op.create_index("ix_user_sessions_active_workspace_id", ["active_workspace_id"])
+        batch_op.create_foreign_key(
+            "fk_user_sessions_active_workspace_id",
+            "workspaces",
+            ["active_workspace_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    for table_name in WORKSPACE_TABLES:
+        with op.batch_alter_table(table_name) as batch_op:
+            batch_op.add_column(sa.Column("workspace_id", sa.Integer(), nullable=True))
+            batch_op.create_index(f"ix_{table_name}_workspace_id", ["workspace_id"])
+            batch_op.create_foreign_key(
+                f"fk_{table_name}_workspace_id",
+                "workspaces",
+                ["workspace_id"],
+                ["id"],
+                ondelete="CASCADE",
+            )
+
+    workspace_name = bind.execute(
+        text("SELECT company_name FROM settings ORDER BY id LIMIT 1")
+    ).scalar() or "Primary Workspace"
+    slug_base = _slugify(workspace_name)
+    slug = slug_base
+    suffix = 2
+    while bind.execute(text("SELECT id FROM workspaces WHERE slug = :slug"), {"slug": slug}).scalar():
+        slug = f"{slug_base}-{suffix}"
+        suffix += 1
+
+    bind.execute(
+        text(
+            """
+            INSERT INTO workspaces (name, slug, is_active, metadata_json, created_at, updated_at)
+            VALUES (:name, :slug, 1, :metadata_json, :created_at, :updated_at)
+            """
+        ),
+        {
+            "name": workspace_name,
+            "slug": slug,
+            "metadata_json": "{}",
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+        },
+    )
+    workspace_id = bind.execute(
+        text("SELECT id FROM workspaces WHERE slug = :slug"),
+        {"slug": slug},
+    ).scalar()
+
+    for table_name in WORKSPACE_TABLES:
+        bind.execute(
+            text(f"UPDATE {table_name} SET workspace_id = :workspace_id WHERE workspace_id IS NULL"),
+            {"workspace_id": workspace_id},
+        )
+
+    bind.execute(
+        text(
+            """
+            INSERT INTO workspace_memberships (workspace_id, user_id, role, is_default, is_active, created_at, updated_at)
+            SELECT :workspace_id, users.id, users.role, 1, users.is_active, :created_at, :updated_at
+            FROM users
+            """
+        ),
+        {"workspace_id": workspace_id, "created_at": datetime.utcnow(), "updated_at": datetime.utcnow()},
+    )
+    bind.execute(
+        text(
+            """
+            UPDATE user_sessions
+            SET active_workspace_id = :workspace_id
+            WHERE active_workspace_id IS NULL
+            """
+        ),
+        {"workspace_id": workspace_id},
+    )
+
+    for table_name in WORKSPACE_TABLES:
+        with op.batch_alter_table(table_name) as batch_op:
+            batch_op.alter_column("workspace_id", nullable=False)
+
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_invoices_workspace_match_insert
+        BEFORE INSERT ON invoices
+        FOR EACH ROW
+        WHEN NEW.client_id IS NOT NULL AND
+             (SELECT workspace_id FROM clients WHERE id = NEW.client_id) != NEW.workspace_id
+        BEGIN
+            SELECT RAISE(ABORT, 'workspace mismatch: invoices.client_id');
+        END;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_invoices_workspace_match_update
+        BEFORE UPDATE ON invoices
+        FOR EACH ROW
+        WHEN NEW.client_id IS NOT NULL AND
+             (SELECT workspace_id FROM clients WHERE id = NEW.client_id) != NEW.workspace_id
+        BEGIN
+            SELECT RAISE(ABORT, 'workspace mismatch: invoices.client_id');
+        END;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_invoice_line_items_workspace_match_insert
+        BEFORE INSERT ON invoice_line_items
+        FOR EACH ROW
+        WHEN (SELECT workspace_id FROM invoices WHERE id = NEW.invoice_id) != NEW.workspace_id
+        BEGIN
+            SELECT RAISE(ABORT, 'workspace mismatch: invoice_line_items.invoice_id');
+        END;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_quote_line_items_workspace_match_insert
+        BEFORE INSERT ON quote_line_items
+        FOR EACH ROW
+        WHEN (SELECT workspace_id FROM quotes WHERE id = NEW.quote_id) != NEW.workspace_id
+        BEGIN
+            SELECT RAISE(ABORT, 'workspace mismatch: quote_line_items.quote_id');
+        END;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_credit_notes_workspace_match_insert
+        BEFORE INSERT ON credit_notes
+        FOR EACH ROW
+        WHEN (SELECT workspace_id FROM invoices WHERE id = NEW.invoice_id) != NEW.workspace_id
+           OR (SELECT workspace_id FROM clients WHERE id = NEW.client_id) != NEW.workspace_id
+        BEGIN
+            SELECT RAISE(ABORT, 'workspace mismatch: credit_notes');
+        END;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_credit_note_line_items_workspace_match_insert
+        BEFORE INSERT ON credit_note_line_items
+        FOR EACH ROW
+        WHEN (SELECT workspace_id FROM credit_notes WHERE id = NEW.credit_note_id) != NEW.workspace_id
+           OR (SELECT workspace_id FROM invoice_line_items WHERE id = NEW.invoice_line_item_id) != NEW.workspace_id
+        BEGIN
+            SELECT RAISE(ABORT, 'workspace mismatch: credit_note_line_items');
+        END;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_refunds_workspace_match_insert
+        BEFORE INSERT ON refunds
+        FOR EACH ROW
+        WHEN (SELECT workspace_id FROM credit_notes WHERE id = NEW.credit_note_id) != NEW.workspace_id
+           OR (SELECT workspace_id FROM invoices WHERE id = NEW.invoice_id) != NEW.workspace_id
+           OR (SELECT workspace_id FROM clients WHERE id = NEW.client_id) != NEW.workspace_id
+        BEGIN
+            SELECT RAISE(ABORT, 'workspace mismatch: refunds');
+        END;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_expenses_workspace_match_insert
+        BEFORE INSERT ON expenses
+        FOR EACH ROW
+        WHEN NEW.client_id IS NOT NULL AND
+             (SELECT workspace_id FROM clients WHERE id = NEW.client_id) != NEW.workspace_id
+        BEGIN
+            SELECT RAISE(ABORT, 'workspace mismatch: expenses.client_id');
+        END;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_invoice_payments_workspace_match_insert
+        BEFORE INSERT ON invoice_payments
+        FOR EACH ROW
+        WHEN (SELECT workspace_id FROM invoices WHERE id = NEW.invoice_id) != NEW.workspace_id
+        BEGIN
+            SELECT RAISE(ABORT, 'workspace mismatch: invoice_payments.invoice_id');
+        END;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS trg_invoice_payments_workspace_match_insert")
+    op.execute("DROP TRIGGER IF EXISTS trg_expenses_workspace_match_insert")
+    op.execute("DROP TRIGGER IF EXISTS trg_refunds_workspace_match_insert")
+    op.execute("DROP TRIGGER IF EXISTS trg_credit_note_line_items_workspace_match_insert")
+    op.execute("DROP TRIGGER IF EXISTS trg_credit_notes_workspace_match_insert")
+    op.execute("DROP TRIGGER IF EXISTS trg_quote_line_items_workspace_match_insert")
+    op.execute("DROP TRIGGER IF EXISTS trg_invoice_line_items_workspace_match_insert")
+    op.execute("DROP TRIGGER IF EXISTS trg_invoices_workspace_match_update")
+    op.execute("DROP TRIGGER IF EXISTS trg_invoices_workspace_match_insert")
+
+    for table_name in WORKSPACE_TABLES:
+        with op.batch_alter_table(table_name) as batch_op:
+            batch_op.drop_constraint(f"fk_{table_name}_workspace_id", type_="foreignkey")
+            batch_op.drop_index(f"ix_{table_name}_workspace_id")
+            batch_op.drop_column("workspace_id")
+
+    with op.batch_alter_table("user_sessions") as batch_op:
+        batch_op.drop_constraint("fk_user_sessions_active_workspace_id", type_="foreignkey")
+        batch_op.drop_index("ix_user_sessions_active_workspace_id")
+        batch_op.drop_column("active_workspace_id")
+
+    op.drop_index("ix_workspace_memberships_user_id", table_name="workspace_memberships")
+    op.drop_index("ix_workspace_memberships_workspace_id", table_name="workspace_memberships")
+    op.drop_index("ix_workspace_memberships_id", table_name="workspace_memberships")
+    op.drop_table("workspace_memberships")
+
+    op.drop_index("ix_workspaces_slug", table_name="workspaces")
+    op.drop_index("ix_workspaces_id", table_name="workspaces")
+    op.drop_table("workspaces")

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Iterable, Optional
 
@@ -7,18 +8,28 @@ from fastapi import Depends, HTTPException, Request, Response, status
 from sqlalchemy.orm import Session
 
 from . import crud, models
-from .db import get_db
-from .security import compare_hash, expires_at, generate_session_token, hash_token
 from .config import settings
+from .db import get_db
+from .security import expires_at, generate_session_token, hash_token
 
 SESSION_COOKIE = "session_token"
+
+
+@dataclass
+class WorkspaceContext:
+    user: models.User
+    session: models.UserSession
+    workspace: models.Workspace
+    membership: models.WorkspaceMembership
 
 
 def _get_token_from_request(request: Request) -> Optional[str]:
     return request.cookies.get(SESSION_COOKIE)
 
 
-def get_current_user(request: Request, db: Session = Depends(get_db)) -> Optional[models.User]:
+def get_current_session(
+    request: Request, db: Session = Depends(get_db)
+) -> Optional[models.UserSession]:
     token = _get_token_from_request(request)
     if not token:
         return None
@@ -28,6 +39,13 @@ def get_current_user(request: Request, db: Session = Depends(get_db)) -> Optiona
         return None
     if session.expires_at < datetime.utcnow():
         crud.delete_session(db, session)
+        return None
+    return session
+
+
+def get_current_user(request: Request, db: Session = Depends(get_db)) -> Optional[models.User]:
+    session = get_current_session(request, db)
+    if not session:
         return None
     return session.user
 
@@ -39,18 +57,88 @@ def require_user(user: models.User | None = Depends(get_current_user)) -> models
 
 
 def require_role(roles: Iterable[str]):
-    def _role_guard(user: models.User = Depends(require_user)) -> models.User:
-        if user.role not in roles:
+    allowed_roles = set(roles)
+
+    def _role_guard(
+        request: Request,
+        user: models.User = Depends(require_user),
+    ) -> models.User:
+        workspace_context = getattr(request.state, "workspace_context", None)
+        effective_role = workspace_context.membership.role if workspace_context else user.role
+        if effective_role not in allowed_roles:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
         return user
 
     return _role_guard
 
 
-def create_session(response: Response, db: Session, user: models.User):
+def resolve_workspace_context(
+    db: Session,
+    user: models.User,
+    session: models.UserSession,
+) -> WorkspaceContext:
+    memberships = (
+        db.query(models.WorkspaceMembership)
+        .filter(
+            models.WorkspaceMembership.user_id == user.id,
+            models.WorkspaceMembership.is_active == True,  # noqa: E712
+        )
+        .order_by(
+            models.WorkspaceMembership.is_default.desc(),
+            models.WorkspaceMembership.id.asc(),
+        )
+        .all()
+    )
+    if not memberships:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="No workspace access.")
+
+    membership_by_workspace = {membership.workspace_id: membership for membership in memberships}
+    membership = None
+    if session.active_workspace_id:
+        membership = membership_by_workspace.get(session.active_workspace_id)
+    if membership is None:
+        membership = next((item for item in memberships if item.is_default), None) or memberships[0]
+        session.active_workspace_id = membership.workspace_id
+        db.commit()
+        db.refresh(session)
+
+    workspace = membership.workspace
+    if not workspace or not workspace.is_active:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Workspace is inactive.")
+
+    return WorkspaceContext(
+        user=user,
+        session=session,
+        workspace=workspace,
+        membership=membership,
+    )
+
+
+def require_workspace_context(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_user),
+) -> WorkspaceContext:
+    context = getattr(request.state, "workspace_context", None)
+    if context:
+        return context
+    session = get_current_session(request, db)
+    if not session:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+    context = resolve_workspace_context(db, user, session)
+    request.state.workspace_context = context
+    return context
+
+
+def create_session(
+    response: Response,
+    db: Session,
+    user: models.User,
+    active_workspace_id: int | None = None,
+):
     token = generate_session_token()
     token_hash = hash_token(token)
-    crud.create_session(db, user, token_hash, expires_at())
+    crud.create_session(db, user, token_hash, expires_at(), active_workspace_id=active_workspace_id)
     response.set_cookie(
         SESSION_COOKIE,
         token,

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 import json
+import re
 
 from sqlalchemy.orm import Session
 
@@ -103,6 +104,26 @@ def _default_tax_rate_catalog_payload():
     }
 
 
+def _slugify_workspace_name(name: str) -> str:
+    base = re.sub(r"[^a-z0-9]+", "-", (name or "").strip().lower()).strip("-")
+    return base or "workspace"
+
+
+def _ensure_workspace_slug(db: Session, name: str, exclude_workspace_id: int | None = None) -> str:
+    base = _slugify_workspace_name(name)
+    slug = base
+    suffix = 2
+    while True:
+        query = db.query(models.Workspace).filter(models.Workspace.slug == slug)
+        if exclude_workspace_id is not None:
+            query = query.filter(models.Workspace.id != exclude_workspace_id)
+        if not query.first():
+            break
+        slug = f"{base}-{suffix}"
+        suffix += 1
+    return slug
+
+
 def _apply_document_totals(document, line_items):
     document.net_amount = _round_money(sum(float(item.net_amount or 0) for item in line_items))
     document.tax_amount = _round_money(sum(float(item.tax_amount or 0) for item in line_items))
@@ -170,8 +191,11 @@ def ensure_display_id_unique(db: Session, model, display_id: str, exclude_id: in
         raise ValueError("Display ID already exists.")
 
 
-def get_or_create_settings(db: Session) -> models.Settings:
-    settings = db.query(models.Settings).first()
+def get_or_create_settings(db: Session, workspace_id: int | None = None) -> models.Settings:
+    settings_query = db.query(models.Settings)
+    if workspace_id is not None:
+        settings_query = settings_query.filter(models.Settings.workspace_id == workspace_id)
+    settings = settings_query.first()
     if settings:
         changed = False
         if not settings.expense_prefix:
@@ -227,14 +251,18 @@ def get_or_create_settings(db: Session) -> models.Settings:
             db.refresh(settings)
         return settings
     settings = models.Settings()
+    if workspace_id is not None:
+        settings.workspace_id = workspace_id
     db.add(settings)
     db.commit()
     db.refresh(settings)
     return settings
 
 
-def update_settings(db: Session, payload: schemas.SettingsUpdate) -> models.Settings:
-    settings = get_or_create_settings(db)
+def update_settings(
+    db: Session, payload: schemas.SettingsUpdate, workspace_id: int | None = None
+) -> models.Settings:
+    settings = get_or_create_settings(db, workspace_id=workspace_id)
     for field, value in payload.model_dump(exclude_unset=True).items():
         if field == "smtp_password":
             if value:
@@ -428,20 +456,35 @@ def get_user(db: Session, user_id: int):
     return db.query(models.User).filter(models.User.id == user_id).first()
 
 
-def list_users(db: Session):
-    return db.query(models.User).order_by(models.User.created_at.desc()).all()
+def list_users(db: Session, workspace_id: int | None = None):
+    query = db.query(models.User)
+    if workspace_id is not None:
+        query = query.join(
+            models.WorkspaceMembership,
+            models.WorkspaceMembership.user_id == models.User.id,
+        ).filter(models.WorkspaceMembership.workspace_id == workspace_id)
+    return query.order_by(models.User.created_at.desc()).all()
 
 
-def list_active_users(db: Session):
-    return (
-        db.query(models.User)
-        .filter(models.User.is_active == True)  # noqa: E712
-        .order_by(models.User.created_at.desc())
-        .all()
-    )
+def list_active_users(db: Session, workspace_id: int | None = None):
+    query = db.query(models.User).filter(models.User.is_active == True)  # noqa: E712
+    if workspace_id is not None:
+        query = query.join(
+            models.WorkspaceMembership,
+            models.WorkspaceMembership.user_id == models.User.id,
+        ).filter(
+            models.WorkspaceMembership.workspace_id == workspace_id,
+            models.WorkspaceMembership.is_active == True,  # noqa: E712
+        )
+    return query.order_by(models.User.created_at.desc()).all()
 
 
-def create_user(db: Session, payload: schemas.UserCreate, role: str | None = None):
+def create_user(
+    db: Session,
+    payload: schemas.UserCreate,
+    role: str | None = None,
+    workspace_id: int | None = None,
+):
     user = models.User(
         email=payload.email,
         password_hash=hash_password(payload.password),
@@ -449,9 +492,142 @@ def create_user(db: Session, payload: schemas.UserCreate, role: str | None = Non
         is_active=payload.is_active,
     )
     db.add(user)
+    db.flush()
+    if workspace_id is not None:
+        existing = get_workspace_membership(db, workspace_id, user.id)
+        if not existing:
+            db.add(
+                models.WorkspaceMembership(
+                    workspace_id=workspace_id,
+                    user_id=user.id,
+                    role=role or payload.role,
+                    is_default=False,
+                    is_active=True,
+                )
+            )
     db.commit()
     db.refresh(user)
     return user
+
+
+def get_workspace(db: Session, workspace_id: int):
+    return db.query(models.Workspace).filter(models.Workspace.id == workspace_id).first()
+
+
+def list_workspaces_for_user(db: Session, user_id: int):
+    return (
+        db.query(models.WorkspaceMembership)
+        .filter(models.WorkspaceMembership.user_id == user_id)
+        .order_by(models.WorkspaceMembership.is_default.desc(), models.WorkspaceMembership.created_at.asc())
+        .all()
+    )
+
+
+def create_workspace(
+    db: Session,
+    payload: schemas.WorkspaceCreate,
+    created_by_user: models.User,
+):
+    workspace = models.Workspace(
+        name=payload.name.strip(),
+        slug=_ensure_workspace_slug(db, payload.name),
+        is_active=True,
+    )
+    db.add(workspace)
+    db.flush()
+    membership = models.WorkspaceMembership(
+        workspace_id=workspace.id,
+        user_id=created_by_user.id,
+        role="owner" if created_by_user.role == "owner" else "admin",
+        is_default=payload.set_default,
+        is_active=True,
+    )
+    db.add(membership)
+    if payload.set_default:
+        (
+            db.query(models.WorkspaceMembership)
+            .filter(
+                models.WorkspaceMembership.user_id == created_by_user.id,
+                models.WorkspaceMembership.workspace_id != workspace.id,
+            )
+            .update({models.WorkspaceMembership.is_default: False}, synchronize_session=False)
+        )
+    db.commit()
+    db.refresh(workspace)
+    return workspace
+
+
+def get_workspace_membership(db: Session, workspace_id: int, user_id: int):
+    return (
+        db.query(models.WorkspaceMembership)
+        .filter(
+            models.WorkspaceMembership.workspace_id == workspace_id,
+            models.WorkspaceMembership.user_id == user_id,
+        )
+        .first()
+    )
+
+
+def list_workspace_members(db: Session, workspace_id: int):
+    return (
+        db.query(models.WorkspaceMembership)
+        .filter(models.WorkspaceMembership.workspace_id == workspace_id)
+        .order_by(models.WorkspaceMembership.created_at.asc())
+        .all()
+    )
+
+
+def update_workspace(db: Session, workspace: models.Workspace, payload: schemas.WorkspaceUpdate):
+    data = payload.model_dump(exclude_unset=True)
+    if "name" in data and data["name"]:
+        workspace.name = data["name"].strip()
+        workspace.slug = _ensure_workspace_slug(db, data["name"], exclude_workspace_id=workspace.id)
+    if "is_active" in data:
+        workspace.is_active = bool(data["is_active"])
+    db.commit()
+    db.refresh(workspace)
+    return workspace
+
+
+def set_default_workspace(db: Session, user_id: int, workspace_id: int):
+    (
+        db.query(models.WorkspaceMembership)
+        .filter(models.WorkspaceMembership.user_id == user_id)
+        .update({models.WorkspaceMembership.is_default: False}, synchronize_session=False)
+    )
+    membership = get_workspace_membership(db, workspace_id, user_id)
+    if membership:
+        membership.is_default = True
+        db.commit()
+        db.refresh(membership)
+    return membership
+
+
+def update_workspace_membership(
+    db: Session,
+    membership: models.WorkspaceMembership,
+    payload: schemas.WorkspaceMembershipUpdate,
+):
+    data = payload.model_dump(exclude_unset=True)
+    for field, value in data.items():
+        setattr(membership, field, value)
+    if data.get("is_default"):
+        (
+            db.query(models.WorkspaceMembership)
+            .filter(
+                models.WorkspaceMembership.user_id == membership.user_id,
+                models.WorkspaceMembership.workspace_id != membership.workspace_id,
+            )
+            .update({models.WorkspaceMembership.is_default: False}, synchronize_session=False)
+        )
+    db.commit()
+    db.refresh(membership)
+    return membership
+
+
+def delete_workspace_membership(db: Session, membership: models.WorkspaceMembership):
+    db.delete(membership)
+    db.commit()
 
 
 def update_user(db: Session, user: models.User, payload: schemas.UserUpdate):
@@ -471,8 +647,19 @@ def delete_user(db: Session, user: models.User):
     db.commit()
 
 
-def create_session(db: Session, user: models.User, token_hash: str, expires_at: datetime):
-    session = models.UserSession(user_id=user.id, token_hash=token_hash, expires_at=expires_at)
+def create_session(
+    db: Session,
+    user: models.User,
+    token_hash: str,
+    expires_at: datetime,
+    active_workspace_id: int | None = None,
+):
+    session = models.UserSession(
+        user_id=user.id,
+        token_hash=token_hash,
+        expires_at=expires_at,
+        active_workspace_id=active_workspace_id,
+    )
     db.add(session)
     db.commit()
     db.refresh(session)
@@ -481,6 +668,15 @@ def create_session(db: Session, user: models.User, token_hash: str, expires_at: 
 
 def get_session_by_hash(db: Session, token_hash: str):
     return db.query(models.UserSession).filter(models.UserSession.token_hash == token_hash).first()
+
+
+def set_session_active_workspace(
+    db: Session, session: models.UserSession, workspace_id: int
+) -> models.UserSession:
+    session.active_workspace_id = workspace_id
+    db.commit()
+    db.refresh(session)
+    return session
 
 
 def delete_session(db: Session, session: models.UserSession):

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,5 +1,7 @@
+from contextvars import ContextVar
+
 from sqlalchemy import create_engine, event
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.orm import Session, declarative_base, sessionmaker, with_loader_criteria
 
 from .config import settings
 
@@ -14,6 +16,76 @@ if settings.database_url.startswith("sqlite"):
         cursor.close()
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 Base = declarative_base()
+_current_workspace_id: ContextVar[int | None] = ContextVar("current_workspace_id", default=None)
+
+
+def set_current_workspace_id(workspace_id: int | None):
+    return _current_workspace_id.set(workspace_id)
+
+
+def reset_current_workspace_id(token):
+    _current_workspace_id.reset(token)
+
+
+def get_current_workspace_id() -> int | None:
+    return _current_workspace_id.get()
+
+
+@event.listens_for(Session, "do_orm_execute")
+def _scope_workspace_selects(execute_state):
+    workspace_id = get_current_workspace_id()
+    if workspace_id is None or not execute_state.is_select:
+        return
+    from . import models
+
+    scoped_models = (
+        models.Client,
+        models.Invoice,
+        models.Quote,
+        models.InvoiceLineItem,
+        models.CreditNote,
+        models.CreditNoteLineItem,
+        models.Refund,
+        models.QuoteLineItem,
+        models.ServiceAgreement,
+        models.ServiceAgreementSLA,
+        models.Proposal,
+        models.ProposalRequirement,
+        models.ProposalAttachment,
+        models.ServiceAgreementVersion,
+        models.ProposalVersion,
+        models.AgreementVersionComment,
+        models.AgreementVersionCommentReaction,
+        models.ProposalVersionComment,
+        models.ProposalVersionCommentReaction,
+        models.Expense,
+        models.ExpenseReceipt,
+        models.EmailLog,
+        models.InvoicePayment,
+        models.PaymentTaxAllocation,
+        models.Settings,
+        models.TaxRateCatalog,
+    )
+    execute_state.statement = execute_state.statement.options(
+        *[
+            with_loader_criteria(
+                model,
+                lambda cls: cls.workspace_id == workspace_id,
+                include_aliases=True,
+            )
+            for model in scoped_models
+        ]
+    )
+
+
+@event.listens_for(Session, "before_flush")
+def _set_workspace_on_new_rows(session, flush_context, instances):
+    workspace_id = get_current_workspace_id()
+    if workspace_id is None:
+        return
+    for obj in session.new:
+        if hasattr(obj, "workspace_id") and getattr(obj, "workspace_id", None) is None:
+            setattr(obj, "workspace_id", workspace_id)
 
 
 def get_db():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,9 +2,11 @@ from datetime import datetime, timedelta, timezone
 from collections import defaultdict
 import mimetypes
 from pathlib import Path
+import re
+import sqlite3
 from uuid import uuid4
 
-from fastapi import Depends, FastAPI, HTTPException, Request, Response, UploadFile, File
+from fastapi import Depends, FastAPI, HTTPException, Request, Response, UploadFile, File, Form
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -13,9 +15,25 @@ from sqlalchemy.orm import Session
 from sqlalchemy import inspect
 
 from . import crud, models, schemas
-from .auth import clear_session, create_session, get_current_user, require_role, require_user
+from .auth import (
+    clear_session,
+    create_session,
+    get_current_session,
+    get_current_user,
+    require_role,
+    require_user,
+    require_workspace_context,
+    resolve_workspace_context,
+)
 from .config import settings
-from .db import Base, engine, get_db, SessionLocal
+from .db import (
+    Base,
+    engine,
+    get_db,
+    SessionLocal,
+    reset_current_workspace_id,
+    set_current_workspace_id,
+)
 from .email_utils import generate_email_draft, send_email_smtp, test_smtp_connection
 from base64 import b64encode, b64decode
 from .security import password_meets_policy, verify_password
@@ -38,6 +56,34 @@ BACKUP_DIR.mkdir(parents=True, exist_ok=True)
 
 MAX_UPLOAD_BYTES = settings.max_upload_mb * 1024 * 1024
 _login_rate_cache: dict[str, dict[str, datetime | int]] = {}
+WORKSPACE_SCOPED_TABLES = [
+    "clients",
+    "invoices",
+    "quotes",
+    "invoice_line_items",
+    "quote_line_items",
+    "credit_notes",
+    "credit_note_line_items",
+    "refunds",
+    "service_agreements",
+    "agreement_slas",
+    "agreement_versions",
+    "agreement_version_comments",
+    "agreement_version_comment_reactions",
+    "proposals",
+    "proposal_requirements",
+    "proposal_attachments",
+    "proposal_versions",
+    "proposal_version_comments",
+    "proposal_version_comment_reactions",
+    "expenses",
+    "expense_receipts",
+    "settings",
+    "tax_rate_catalogs",
+    "email_logs",
+    "invoice_payments",
+    "payment_tax_allocations",
+]
 
 
 def _resolve_db_path() -> Path:
@@ -111,6 +157,106 @@ def _restore_from_archive(archive_path: Path):
             _clear_uploads()
             shutil.copytree(extracted_uploads, UPLOADS_DIR, dirs_exist_ok=True)
 
+
+def _slugify_filename_part(value: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", "-", (value or "").strip().lower()).strip("-")
+    return cleaned or "workspace"
+
+
+def _create_sqlite_snapshot(source_db: Path, target_db: Path):
+    source_conn = sqlite3.connect(str(source_db))
+    try:
+        target_conn = sqlite3.connect(str(target_db))
+        try:
+            source_conn.backup(target_conn)
+        finally:
+            target_conn.close()
+    finally:
+        source_conn.close()
+
+
+def _create_workspace_sqlite_snapshot(source_db: Path, target_db: Path, workspace_id: int):
+    _create_sqlite_snapshot(source_db, target_db)
+    conn = sqlite3.connect(str(target_db))
+    try:
+        cur = conn.cursor()
+        cur.execute("PRAGMA foreign_keys=OFF")
+        for table_name in WORKSPACE_SCOPED_TABLES:
+            cur.execute(f"DELETE FROM {table_name} WHERE workspace_id != ?", (workspace_id,))
+        cur.execute("DELETE FROM workspace_memberships WHERE workspace_id != ?", (workspace_id,))
+        cur.execute("DELETE FROM workspaces WHERE id != ?", (workspace_id,))
+        cur.execute("SELECT DISTINCT user_id FROM workspace_memberships WHERE workspace_id = ?", (workspace_id,))
+        user_ids = [row[0] for row in cur.fetchall()]
+        if user_ids:
+            placeholders = ",".join("?" for _ in user_ids)
+            cur.execute(f"DELETE FROM users WHERE id NOT IN ({placeholders})", tuple(user_ids))
+            cur.execute(
+                f"DELETE FROM user_sessions WHERE user_id NOT IN ({placeholders})",
+                tuple(user_ids),
+            )
+            cur.execute(
+                "UPDATE user_sessions SET active_workspace_id = ? WHERE user_id IN "
+                f"({placeholders})",
+                tuple([workspace_id, *user_ids]),
+            )
+        else:
+            cur.execute("DELETE FROM users")
+            cur.execute("DELETE FROM user_sessions")
+        cur.execute("PRAGMA foreign_keys=ON")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _workspace_upload_paths(db: Session, workspace_id: int) -> set[str]:
+    proposal_paths = (
+        db.query(models.ProposalAttachment.file_path)
+        .filter(models.ProposalAttachment.workspace_id == workspace_id)
+        .all()
+    )
+    receipt_paths = (
+        db.query(models.ExpenseReceipt.file_path)
+        .filter(models.ExpenseReceipt.workspace_id == workspace_id)
+        .all()
+    )
+    return {
+        str(path)
+        for (path,) in [*proposal_paths, *receipt_paths]
+        if path
+    }
+
+
+def _delete_upload_paths(paths: set[str]):
+    for relative in paths:
+        clean = str(relative).strip()
+        if clean.startswith("uploads/"):
+            clean = clean[len("uploads/"):]
+        target = (UPLOADS_DIR / clean).resolve()
+        try:
+            target.relative_to(UPLOADS_DIR.resolve())
+        except ValueError:
+            continue
+        if target.exists() and target.is_file():
+            target.unlink(missing_ok=True)
+
+
+def _copy_workspace_uploads_to_temp(paths: set[str], destination: Path):
+    destination.mkdir(parents=True, exist_ok=True)
+    for relative in paths:
+        clean = str(relative).strip()
+        if clean.startswith("uploads/"):
+            clean = clean[len("uploads/"):]
+        source = (UPLOADS_DIR / clean).resolve()
+        try:
+            source.relative_to(UPLOADS_DIR.resolve())
+        except ValueError:
+            continue
+        if not source.exists() or not source.is_file():
+            continue
+        target = destination / clean
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(source.read_bytes())
+
 allowed_origins = [
     origin.strip()
     for origin in settings.allowed_origins.split(",")
@@ -149,14 +295,31 @@ async def auth_gate(request: Request, call_next):
     if request.method == "OPTIONS" or request.url.path in _AUTH_ALLOWLIST:
         return await call_next(request)
     db = SessionLocal()
+    workspace_token = None
+    context_error = None
     try:
-        user = get_current_user(request, db)
+        session = get_current_session(request, db)
+        user = session.user if session else None
+        if user:
+            try:
+                context = resolve_workspace_context(db, user, session)
+            except HTTPException as exc:
+                context_error = exc
+            else:
+                request.state.workspace_context = context
+                workspace_token = set_current_workspace_id(context.workspace.id)
     finally:
         db.close()
     if not user:
         return JSONResponse(status_code=401, content={"detail": "Not authenticated"})
+    if context_error:
+        return JSONResponse(status_code=context_error.status_code, content={"detail": context_error.detail})
     request.state.user = user
-    return await call_next(request)
+    try:
+        return await call_next(request)
+    finally:
+        if workspace_token is not None:
+            reset_current_workspace_id(workspace_token)
 
 
 @app.get("/health")
@@ -191,9 +354,13 @@ def test_smtp(user=Depends(require_role(["owner", "admin"]))):
 
 
 @app.post("/admin/backup")
-def create_backup(payload: schemas.BackupRequest, user=Depends(require_role(["owner", "admin"]))):
+def create_backup(
+    payload: schemas.BackupRequest,
+    db: Session = Depends(get_db),
+    user=Depends(require_role(["owner", "admin"])),
+    context=Depends(require_workspace_context),
+):
     import tarfile
-    from datetime import datetime
     import tempfile
 
     source_db = _resolve_db_path()
@@ -203,8 +370,12 @@ def create_backup(payload: schemas.BackupRequest, user=Depends(require_role(["ow
     if not payload.download and not payload.store:
         raise HTTPException(status_code=400, detail="Select download and/or store.")
 
-    timestamp = datetime.utcnow().strftime("%Y-%m-%d")
-    backup_name = f"cms-{timestamp}.tar.gz"
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d_%H-%M-%S")
+    workspace_part = _slugify_filename_part(context.workspace.name)
+    if payload.scope == "tenant":
+        backup_name = f"cms-tenant-{timestamp}.tar.gz"
+    else:
+        backup_name = f"cms-workspace-{workspace_part}-{timestamp}.tar.gz"
 
     if payload.store:
         backup_path = BACKUP_DIR / backup_name
@@ -213,10 +384,34 @@ def create_backup(payload: schemas.BackupRequest, user=Depends(require_role(["ow
         backup_path = Path(temp_file.name)
         temp_file.close()
 
-    with tarfile.open(backup_path, "w:gz") as tar:
-        tar.add(str(source_db), arcname="app.db")
-        if UPLOADS_DIR.exists():
-            tar.add(str(UPLOADS_DIR), arcname="uploads")
+    with tempfile.NamedTemporaryFile(prefix="cms-db-snapshot-", suffix=".db", delete=False) as snapshot_file:
+        snapshot_path = Path(snapshot_file.name)
+    workspace_upload_dir = Path(
+        tempfile.mkdtemp(prefix="cms-workspace-uploads-")
+    ) if payload.scope == "workspace" else None
+    try:
+        if payload.scope == "workspace":
+            _create_workspace_sqlite_snapshot(source_db, snapshot_path, context.workspace.id)
+        else:
+            _create_sqlite_snapshot(source_db, snapshot_path)
+        with tarfile.open(backup_path, "w:gz") as tar:
+            tar.add(str(snapshot_path), arcname="app.db")
+            if payload.scope == "workspace":
+                upload_paths = _workspace_upload_paths(db, context.workspace.id)
+                if workspace_upload_dir is not None:
+                    _copy_workspace_uploads_to_temp(upload_paths, workspace_upload_dir)
+                    tar.add(str(workspace_upload_dir), arcname="uploads")
+            elif UPLOADS_DIR.exists():
+                tar.add(str(UPLOADS_DIR), arcname="uploads")
+    finally:
+        snapshot_path.unlink(missing_ok=True)
+        if workspace_upload_dir and workspace_upload_dir.exists():
+            for path in sorted(workspace_upload_dir.rglob("*"), reverse=True):
+                if path.is_file():
+                    path.unlink(missing_ok=True)
+                elif path.is_dir():
+                    path.rmdir()
+            workspace_upload_dir.rmdir()
 
     if payload.download:
         background = None
@@ -229,7 +424,7 @@ def create_backup(payload: schemas.BackupRequest, user=Depends(require_role(["ow
             background=background,
         )
 
-    return {"status": "stored", "filename": backup_name}
+    return {"status": "stored", "filename": backup_name, "scope": payload.scope}
 
 
 @app.get("/admin/backups")
@@ -242,16 +437,43 @@ def list_backups(user=Depends(require_role(["owner", "admin"]))):
 
 
 @app.post("/admin/restore")
-def restore_backup(payload: schemas.RestoreRequest, user=Depends(require_role(["owner", "admin"]))):
+def restore_backup(
+    payload: schemas.RestoreRequest,
+    user=Depends(require_role(["owner", "admin"])),
+):
+    if not payload.workspace_name.strip():
+        raise HTTPException(status_code=400, detail="Workspace name is required.")
     archive_path = BACKUP_DIR / payload.filename
     _restore_from_archive(archive_path)
-    return {"status": "restored", "source": "server", "filename": payload.filename}
+    db = SessionLocal()
+    try:
+        workspace = db.query(models.Workspace).order_by(models.Workspace.id.asc()).first()
+        if workspace:
+            workspace.name = payload.workspace_name.strip()
+            workspace.slug = crud._ensure_workspace_slug(
+                db, payload.workspace_name.strip(), exclude_workspace_id=workspace.id
+            )
+            db.commit()
+    finally:
+        db.close()
+    return {
+        "status": "restored",
+        "source": "server",
+        "filename": payload.filename,
+        "workspace_name": payload.workspace_name.strip(),
+    }
 
 
 @app.post("/admin/restore/upload")
-def restore_backup_upload(file: UploadFile = File(...), user=Depends(require_role(["owner", "admin"]))):
+def restore_backup_upload(
+    file: UploadFile = File(...),
+    workspace_name: str = Form(...),
+    user=Depends(require_role(["owner", "admin"])),
+):
     import tempfile
     filename = file.filename or ""
+    if not workspace_name.strip():
+        raise HTTPException(status_code=400, detail="Workspace name is required.")
     if not filename.endswith(".tar.gz"):
         raise HTTPException(status_code=400, detail="Only .tar.gz backups are supported.")
     temp_file = tempfile.NamedTemporaryFile(prefix="cms-restore-", suffix=".tar.gz", delete=False)
@@ -262,68 +484,90 @@ def restore_backup_upload(file: UploadFile = File(...), user=Depends(require_rol
         _restore_from_archive(temp_path)
     finally:
         temp_path.unlink(missing_ok=True)
-    return {"status": "restored", "source": "upload"}
+    db = SessionLocal()
+    try:
+        workspace = db.query(models.Workspace).order_by(models.Workspace.id.asc()).first()
+        if workspace:
+            workspace.name = workspace_name.strip()
+            workspace.slug = crud._ensure_workspace_slug(
+                db, workspace_name.strip(), exclude_workspace_id=workspace.id
+            )
+            db.commit()
+    finally:
+        db.close()
+    return {"status": "restored", "source": "upload", "workspace_name": workspace_name.strip()}
 
 
 @app.post("/admin/reset")
-def reset_data(db: Session = Depends(get_db), user=Depends(require_role(["owner", "admin"]))):
-    db.query(models.AgreementVersionCommentReaction).delete()
-    db.query(models.AgreementVersionComment).delete()
-    db.query(models.ProposalVersionCommentReaction).delete()
-    db.query(models.ProposalVersionComment).delete()
-    db.query(models.ServiceAgreementVersion).delete()
-    db.query(models.ProposalVersion).delete()
-    db.query(models.ExpenseReceipt).delete()
-    db.query(models.ProposalAttachment).delete()
-    db.query(models.ProposalRequirement).delete()
-    db.query(models.ServiceAgreementSLA).delete()
-    db.query(models.InvoiceLineItem).delete()
-    db.query(models.QuoteLineItem).delete()
-    db.query(models.Proposal).delete()
-    db.query(models.ServiceAgreement).delete()
-    db.query(models.Invoice).delete()
-    db.query(models.Quote).delete()
-    db.query(models.Expense).delete()
-    db.query(models.Client).delete()
+def reset_data(
+    db: Session = Depends(get_db),
+    user=Depends(require_role(["owner", "admin"])),
+    context=Depends(require_workspace_context),
+):
+    workspace_id = context.workspace.id
+    upload_paths = _workspace_upload_paths(db, workspace_id)
+    db.query(models.AgreementVersionCommentReaction).filter(models.AgreementVersionCommentReaction.workspace_id == workspace_id).delete()
+    db.query(models.AgreementVersionComment).filter(models.AgreementVersionComment.workspace_id == workspace_id).delete()
+    db.query(models.ProposalVersionCommentReaction).filter(models.ProposalVersionCommentReaction.workspace_id == workspace_id).delete()
+    db.query(models.ProposalVersionComment).filter(models.ProposalVersionComment.workspace_id == workspace_id).delete()
+    db.query(models.ServiceAgreementVersion).filter(models.ServiceAgreementVersion.workspace_id == workspace_id).delete()
+    db.query(models.ProposalVersion).filter(models.ProposalVersion.workspace_id == workspace_id).delete()
+    db.query(models.ExpenseReceipt).filter(models.ExpenseReceipt.workspace_id == workspace_id).delete()
+    db.query(models.ProposalAttachment).filter(models.ProposalAttachment.workspace_id == workspace_id).delete()
+    db.query(models.ProposalRequirement).filter(models.ProposalRequirement.workspace_id == workspace_id).delete()
+    db.query(models.ServiceAgreementSLA).filter(models.ServiceAgreementSLA.workspace_id == workspace_id).delete()
+    db.query(models.InvoiceLineItem).filter(models.InvoiceLineItem.workspace_id == workspace_id).delete()
+    db.query(models.QuoteLineItem).filter(models.QuoteLineItem.workspace_id == workspace_id).delete()
+    db.query(models.Proposal).filter(models.Proposal.workspace_id == workspace_id).delete()
+    db.query(models.ServiceAgreement).filter(models.ServiceAgreement.workspace_id == workspace_id).delete()
+    db.query(models.Invoice).filter(models.Invoice.workspace_id == workspace_id).delete()
+    db.query(models.Quote).filter(models.Quote.workspace_id == workspace_id).delete()
+    db.query(models.Expense).filter(models.Expense.workspace_id == workspace_id).delete()
+    db.query(models.Client).filter(models.Client.workspace_id == workspace_id).delete()
     db.commit()
+    _delete_upload_paths(upload_paths)
 
-    if UPLOADS_DIR.exists():
-        for item in UPLOADS_DIR.iterdir():
-            if item.name == ".gitkeep":
-                continue
-            if item.is_file():
-                item.unlink()
-            elif item.is_dir():
-                for child in item.rglob("*"):
-                    if child.is_file():
-                        child.unlink()
-                for child in sorted(item.rglob("*"), reverse=True):
-                    if child.is_dir():
-                        child.rmdir()
-                item.rmdir()
-
-    return {"status": "reset"}
+    return {"status": "reset", "workspace_id": workspace_id}
 
 
 @app.post("/admin/reset-workspace")
-def reset_workspace(db: Session = Depends(get_db), user=Depends(require_role(["owner"]))):
-    # Remove business data first.
-    reset_data(db, user)
-
-    # Remove auth/session data and settings.
-    db.query(models.UserSession).delete()
-    db.query(models.User).delete()
-    db.query(models.Settings).delete()
+def reset_workspace(
+    payload: schemas.ResetWorkspaceRequest,
+    db: Session = Depends(get_db),
+    user=Depends(require_role(["owner"])),
+    context=Depends(require_workspace_context),
+):
+    workspace = crud.get_workspace(db, context.workspace.id)
+    if not workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    if payload.workspace_name_confirm.strip() != workspace.name.strip():
+        raise HTTPException(status_code=400, detail="Workspace name confirmation does not match.")
+    total_workspaces = db.query(models.Workspace).count()
+    if total_workspaces <= 1:
+        raise HTTPException(status_code=400, detail="Cannot delete the last remaining workspace.")
+    upload_paths = _workspace_upload_paths(db, workspace.id)
+    db.delete(workspace)
     db.commit()
-
-    return {"status": "workspace_reset"}
+    _delete_upload_paths(upload_paths)
+    return {"status": "workspace_reset", "workspace_id": context.workspace.id}
 
 
 @app.get("/auth/status", response_model=schemas.AuthStatus)
 def auth_status(request: Request, db: Session = Depends(get_db)):
     needs_setup = db.query(models.User).count() == 0
     user = get_current_user(request, db) if request else None
-    return schemas.AuthStatus(needs_setup=needs_setup, user=user)
+    if not user:
+        return schemas.AuthStatus(needs_setup=needs_setup, user=None, workspaces=[])
+    session = get_current_session(request, db) if request else None
+    context = resolve_workspace_context(db, user, session) if session else None
+    workspaces = crud.list_workspaces_for_user(db, user.id)
+    return schemas.AuthStatus(
+        needs_setup=needs_setup,
+        user=user,
+        active_workspace=context.workspace if context else None,
+        workspace_role=context.membership.role if context else None,
+        workspaces=workspaces,
+    )
 
 
 @app.post("/auth/setup", response_model=schemas.AuthStatus)
@@ -345,10 +589,22 @@ def auth_setup(payload: schemas.AuthSetupRequest, response: Response, db: Sessio
     settings_data = payload.model_dump(exclude_none=True)
     settings_data.pop("owner_email", None)
     settings_data.pop("password", None)
+    workspace_name = (payload.company_name or "").strip() or "Primary Workspace"
+    workspace = crud.create_workspace(
+        db,
+        schemas.WorkspaceCreate(name=workspace_name, set_default=True),
+        user,
+    )
     settings_payload = schemas.SettingsUpdate(**settings_data)
-    crud.update_settings(db, settings_payload)
-    create_session(response, db, user)
-    return schemas.AuthStatus(needs_setup=False, user=user)
+    crud.update_settings(db, settings_payload, workspace_id=workspace.id)
+    create_session(response, db, user, active_workspace_id=workspace.id)
+    return schemas.AuthStatus(
+        needs_setup=False,
+        user=user,
+        active_workspace=workspace,
+        workspace_role="owner",
+        workspaces=crud.list_workspaces_for_user(db, user.id),
+    )
 
 
 def _get_client_ip(request: Request) -> str:
@@ -382,8 +638,17 @@ def auth_login(payload: schemas.AuthLoginRequest, response: Response, request: R
         raise HTTPException(status_code=401, detail="Invalid credentials.")
     if not user.is_active:
         raise HTTPException(status_code=403, detail="User is inactive.")
-    create_session(response, db, user)
-    return schemas.AuthStatus(needs_setup=False, user=user)
+    memberships = crud.list_workspaces_for_user(db, user.id)
+    default_membership = next((item for item in memberships if item.is_default), None) or (memberships[0] if memberships else None)
+    active_workspace_id = default_membership.workspace_id if default_membership else None
+    create_session(response, db, user, active_workspace_id=active_workspace_id)
+    return schemas.AuthStatus(
+        needs_setup=False,
+        user=user,
+        active_workspace=default_membership.workspace if default_membership else None,
+        workspace_role=default_membership.role if default_membership else None,
+        workspaces=memberships,
+    )
 
 
 @app.post("/auth/logout")
@@ -392,14 +657,144 @@ def auth_logout(response: Response, request: Request, db: Session = Depends(get_
     return {"status": "ok"}
 
 
+@app.get("/workspaces", response_model=list[schemas.WorkspaceMembershipOut])
+def list_workspaces(
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+):
+    return crud.list_workspaces_for_user(db, user.id)
+
+
+@app.post("/workspaces", response_model=schemas.WorkspaceOut)
+def create_workspace(
+    payload: schemas.WorkspaceCreate,
+    db: Session = Depends(get_db),
+    user=Depends(require_role(["owner", "admin"])),
+):
+    return crud.create_workspace(db, payload, user)
+
+
+@app.patch("/workspaces/{workspace_id}", response_model=schemas.WorkspaceOut)
+def update_workspace(
+    workspace_id: int,
+    payload: schemas.WorkspaceUpdate,
+    db: Session = Depends(get_db),
+    context=Depends(require_workspace_context),
+):
+    if context.membership.role not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    workspace = crud.get_workspace(db, workspace_id)
+    if not workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    membership = crud.get_workspace_membership(db, workspace_id, context.user.id)
+    if not membership or not membership.is_active:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return crud.update_workspace(db, workspace, payload)
+
+
+@app.post("/workspaces/switch", response_model=schemas.WorkspaceSwitchResponse)
+def switch_workspace(
+    payload: schemas.WorkspaceSwitchRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+):
+    session = get_current_session(request, db)
+    if not session:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    membership = crud.get_workspace_membership(db, payload.workspace_id, user.id)
+    if not membership or not membership.is_active:
+        raise HTTPException(status_code=403, detail="No access to workspace")
+    workspace = membership.workspace
+    if not workspace or not workspace.is_active:
+        raise HTTPException(status_code=403, detail="Workspace is inactive")
+    crud.set_session_active_workspace(db, session, workspace.id)
+    return schemas.WorkspaceSwitchResponse(
+        active_workspace=workspace,
+        membership_role=membership.role,
+    )
+
+
+@app.post("/workspaces/{workspace_id}/set-default", response_model=schemas.WorkspaceMembershipOut)
+def set_default_workspace(
+    workspace_id: int,
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+):
+    membership = crud.get_workspace_membership(db, workspace_id, user.id)
+    if not membership or not membership.is_active:
+        raise HTTPException(status_code=403, detail="No access to workspace")
+    updated = crud.set_default_workspace(db, user.id, workspace_id)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Workspace membership not found")
+    return updated
+
+
+@app.get("/workspaces/{workspace_id}/members", response_model=list[schemas.WorkspaceMembershipOut])
+def list_workspace_members(
+    workspace_id: int,
+    db: Session = Depends(get_db),
+    context=Depends(require_workspace_context),
+):
+    membership = crud.get_workspace_membership(db, workspace_id, context.user.id)
+    if not membership or not membership.is_active:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    if context.membership.role not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return crud.list_workspace_members(db, workspace_id)
+
+
+@app.put("/workspaces/{workspace_id}/members/{user_id}", response_model=schemas.WorkspaceMembershipOut)
+def update_workspace_member(
+    workspace_id: int,
+    user_id: int,
+    payload: schemas.WorkspaceMembershipUpdate,
+    db: Session = Depends(get_db),
+    context=Depends(require_workspace_context),
+):
+    if context.membership.role not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    actor_membership = crud.get_workspace_membership(db, workspace_id, context.user.id)
+    if not actor_membership or not actor_membership.is_active:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    membership = crud.get_workspace_membership(db, workspace_id, user_id)
+    if not membership:
+        raise HTTPException(status_code=404, detail="Membership not found")
+    return crud.update_workspace_membership(db, membership, payload)
+
+
+@app.delete("/workspaces/{workspace_id}/members/{user_id}")
+def delete_workspace_member(
+    workspace_id: int,
+    user_id: int,
+    db: Session = Depends(get_db),
+    context=Depends(require_workspace_context),
+):
+    if context.membership.role not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    membership = crud.get_workspace_membership(db, workspace_id, user_id)
+    if not membership:
+        raise HTTPException(status_code=404, detail="Membership not found")
+    crud.delete_workspace_membership(db, membership)
+    return {"status": "deleted"}
+
+
 @app.get("/auth/users", response_model=list[schemas.UserOut])
-def list_users(db: Session = Depends(get_db), user=Depends(require_role(["owner"]))):
-    return crud.list_users(db)
+def list_users(
+    db: Session = Depends(get_db),
+    user=Depends(require_role(["owner"])),
+    context=Depends(require_workspace_context),
+):
+    return crud.list_users(db, workspace_id=context.workspace.id)
 
 
 @app.get("/auth/users/assignable", response_model=list[schemas.UserOut])
-def list_assignable_users(db: Session = Depends(get_db), user=Depends(require_user)):
-    return crud.list_active_users(db)
+def list_assignable_users(
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+    context=Depends(require_workspace_context),
+):
+    return crud.list_active_users(db, workspace_id=context.workspace.id)
 
 
 @app.get("/auth/users/search", response_model=list[schemas.UserSearchOut])
@@ -407,13 +802,19 @@ def search_users(
     q: str,
     db: Session = Depends(get_db),
     user=Depends(require_user),
+    context=Depends(require_workspace_context),
 ):
     term = q.strip()
     if not term:
         return []
     results = (
         db.query(models.User)
+        .join(models.WorkspaceMembership, models.WorkspaceMembership.user_id == models.User.id)
         .filter(models.User.is_active == True)  # noqa: E712
+        .filter(
+            models.WorkspaceMembership.workspace_id == context.workspace.id,
+            models.WorkspaceMembership.is_active == True,  # noqa: E712
+        )
         .filter(models.User.email.ilike(f"%{term}%"))
         .order_by(models.User.email.asc())
         .limit(10)
@@ -423,18 +824,46 @@ def search_users(
 
 
 @app.post("/auth/users", response_model=schemas.UserOut)
-def create_user(payload: schemas.UserCreate, db: Session = Depends(get_db), user=Depends(require_role(["owner"]))):
+def create_user(
+    payload: schemas.UserCreate,
+    db: Session = Depends(get_db),
+    user=Depends(require_role(["owner"])),
+    context=Depends(require_workspace_context),
+):
     if not password_meets_policy(payload.password):
         raise HTTPException(status_code=400, detail="Password does not meet requirements.")
-    if crud.get_user_by_email(db, payload.email):
-        raise HTTPException(status_code=400, detail="User already exists.")
-    return crud.create_user(db, payload)
+    existing = crud.get_user_by_email(db, payload.email)
+    if existing:
+        membership = crud.get_workspace_membership(db, context.workspace.id, existing.id)
+        if membership:
+            raise HTTPException(status_code=400, detail="User already exists in this workspace.")
+        membership = models.WorkspaceMembership(
+            workspace_id=context.workspace.id,
+            user_id=existing.id,
+            role=payload.role,
+            is_active=payload.is_active,
+            is_default=False,
+        )
+        db.add(membership)
+        db.commit()
+        db.refresh(existing)
+        return existing
+    return crud.create_user(db, payload, workspace_id=context.workspace.id)
 
 
 @app.put("/auth/users/{user_id}", response_model=schemas.UserOut)
-def update_user(user_id: int, payload: schemas.UserUpdate, db: Session = Depends(get_db), user=Depends(require_role(["owner"]))):
+def update_user(
+    user_id: int,
+    payload: schemas.UserUpdate,
+    db: Session = Depends(get_db),
+    user=Depends(require_role(["owner"])),
+    context=Depends(require_workspace_context),
+):
     target = crud.get_user(db, user_id)
     if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+    membership = crud.get_workspace_membership(db, context.workspace.id, user_id)
+    if not membership:
         raise HTTPException(status_code=404, detail="User not found")
     if payload.password and not password_meets_policy(payload.password):
         raise HTTPException(status_code=400, detail="Password does not meet requirements.")
@@ -442,11 +871,24 @@ def update_user(user_id: int, payload: schemas.UserUpdate, db: Session = Depends
 
 
 @app.delete("/auth/users/{user_id}")
-def delete_user(user_id: int, db: Session = Depends(get_db), user=Depends(require_role(["owner"]))):
+def delete_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    user=Depends(require_role(["owner"])),
+    context=Depends(require_workspace_context),
+):
     target = crud.get_user(db, user_id)
     if not target:
         raise HTTPException(status_code=404, detail="User not found")
-    crud.delete_user(db, target)
+    membership = crud.get_workspace_membership(db, context.workspace.id, user_id)
+    if not membership:
+        raise HTTPException(status_code=404, detail="User not found")
+    crud.delete_workspace_membership(db, membership)
+    remaining = db.query(models.WorkspaceMembership).filter(models.WorkspaceMembership.user_id == user_id).count()
+    if remaining == 0:
+        target = crud.get_user(db, user_id)
+        if target:
+            crud.delete_user(db, target)
     return {"status": "deleted"}
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,12 +1,63 @@
 from datetime import datetime
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Numeric, String, Text, UniqueConstraint, JSON
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from .db import Base
 
 
-class Client(Base):
+class Workspace(Base):
+    __tablename__ = "workspaces"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    slug: Mapped[str] = mapped_column(String(200), nullable=False, unique=True, index=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    metadata_json: Mapped[dict | None] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    memberships: Mapped[list["WorkspaceMembership"]] = relationship(
+        "WorkspaceMembership", back_populates="workspace", cascade="all, delete-orphan"
+    )
+
+
+class WorkspaceMembership(Base):
+    __tablename__ = "workspace_memberships"
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "user_id", name="uq_workspace_membership"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    workspace_id: Mapped[int] = mapped_column(
+        ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    role: Mapped[str] = mapped_column(String(20), default="user")
+    is_default: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    workspace: Mapped["Workspace"] = relationship("Workspace", back_populates="memberships")
+    user: Mapped["User"] = relationship("User", back_populates="workspace_memberships")
+
+
+class WorkspaceScoped:
+    @declared_attr
+    def workspace_id(cls):  # noqa: N805
+        return mapped_column(
+            ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True
+        )
+
+
+class Client(WorkspaceScoped, Base):
     __tablename__ = "clients"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -39,7 +90,7 @@ class Client(Base):
     )
 
 
-class Invoice(Base):
+class Invoice(WorkspaceScoped, Base):
     __tablename__ = "invoices"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -79,7 +130,7 @@ class Invoice(Base):
     )
 
 
-class Quote(Base):
+class Quote(WorkspaceScoped, Base):
     __tablename__ = "quotes"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -114,7 +165,7 @@ class Quote(Base):
     )
 
 
-class InvoiceLineItem(Base):
+class InvoiceLineItem(WorkspaceScoped, Base):
     __tablename__ = "invoice_line_items"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -139,7 +190,7 @@ class InvoiceLineItem(Base):
     )
 
 
-class CreditNote(Base):
+class CreditNote(WorkspaceScoped, Base):
     __tablename__ = "credit_notes"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -168,7 +219,7 @@ class CreditNote(Base):
     )
 
 
-class CreditNoteLineItem(Base):
+class CreditNoteLineItem(WorkspaceScoped, Base):
     __tablename__ = "credit_note_line_items"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -196,7 +247,7 @@ class CreditNoteLineItem(Base):
     )
 
 
-class Refund(Base):
+class Refund(WorkspaceScoped, Base):
     __tablename__ = "refunds"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -223,7 +274,7 @@ class Refund(Base):
     invoice: Mapped["Invoice"] = relationship("Invoice")
 
 
-class QuoteLineItem(Base):
+class QuoteLineItem(WorkspaceScoped, Base):
     __tablename__ = "quote_line_items"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -245,7 +296,7 @@ class QuoteLineItem(Base):
     quote: Mapped["Quote"] = relationship("Quote", back_populates="line_items")
 
 
-class ServiceAgreement(Base):
+class ServiceAgreement(WorkspaceScoped, Base):
     __tablename__ = "service_agreements"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -296,7 +347,7 @@ class ServiceAgreement(Base):
         return self.updated_by.email if self.updated_by else None
 
 
-class ServiceAgreementSLA(Base):
+class ServiceAgreementSLA(WorkspaceScoped, Base):
     __tablename__ = "agreement_slas"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -309,7 +360,7 @@ class ServiceAgreementSLA(Base):
     agreement: Mapped["ServiceAgreement"] = relationship("ServiceAgreement", back_populates="sla_items")
 
 
-class Proposal(Base):
+class Proposal(WorkspaceScoped, Base):
     __tablename__ = "proposals"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -353,7 +404,7 @@ class Proposal(Base):
         return self.updated_by.email if self.updated_by else None
 
 
-class ProposalRequirement(Base):
+class ProposalRequirement(WorkspaceScoped, Base):
     __tablename__ = "proposal_requirements"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -365,7 +416,7 @@ class ProposalRequirement(Base):
     proposal: Mapped["Proposal"] = relationship("Proposal", back_populates="requirements")
 
 
-class ProposalAttachment(Base):
+class ProposalAttachment(WorkspaceScoped, Base):
     __tablename__ = "proposal_attachments"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -378,7 +429,7 @@ class ProposalAttachment(Base):
     proposal: Mapped["Proposal"] = relationship("Proposal", back_populates="attachments")
 
 
-class ServiceAgreementVersion(Base):
+class ServiceAgreementVersion(WorkspaceScoped, Base):
     __tablename__ = "agreement_versions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -402,7 +453,7 @@ class ServiceAgreementVersion(Base):
         return self.created_by.email if self.created_by else None
 
 
-class ProposalVersion(Base):
+class ProposalVersion(WorkspaceScoped, Base):
     __tablename__ = "proposal_versions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -428,7 +479,7 @@ class ProposalVersion(Base):
         return self.created_by.email if self.created_by else None
 
 
-class AgreementVersionComment(Base):
+class AgreementVersionComment(WorkspaceScoped, Base):
     __tablename__ = "agreement_version_comments"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -462,7 +513,7 @@ class AgreementVersionComment(Base):
         return bool(self.version.is_current) if self.version else False
 
 
-class AgreementVersionCommentReaction(Base):
+class AgreementVersionCommentReaction(WorkspaceScoped, Base):
     __tablename__ = "agreement_version_comment_reactions"
     __table_args__ = (UniqueConstraint("comment_id", "user_id", name="uq_agreement_comment_user"),)
 
@@ -475,7 +526,7 @@ class AgreementVersionCommentReaction(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
-class ProposalVersionComment(Base):
+class ProposalVersionComment(WorkspaceScoped, Base):
     __tablename__ = "proposal_version_comments"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -509,7 +560,7 @@ class ProposalVersionComment(Base):
         return bool(self.version.is_current) if self.version else False
 
 
-class ProposalVersionCommentReaction(Base):
+class ProposalVersionCommentReaction(WorkspaceScoped, Base):
     __tablename__ = "proposal_version_comment_reactions"
     __table_args__ = (UniqueConstraint("comment_id", "user_id", name="uq_proposal_comment_user"),)
 
@@ -522,7 +573,7 @@ class ProposalVersionCommentReaction(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
-class Expense(Base):
+class Expense(WorkspaceScoped, Base):
     __tablename__ = "expenses"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -553,7 +604,7 @@ class Expense(Base):
     )
 
 
-class ExpenseReceipt(Base):
+class ExpenseReceipt(WorkspaceScoped, Base):
     __tablename__ = "expense_receipts"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -566,7 +617,7 @@ class ExpenseReceipt(Base):
     expense: Mapped["Expense"] = relationship("Expense", back_populates="receipts")
 
 
-class EmailLog(Base):
+class EmailLog(WorkspaceScoped, Base):
     __tablename__ = "email_logs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -596,7 +647,7 @@ class EmailLog(Base):
     created_by: Mapped["User"] = relationship("User")
 
 
-class InvoicePayment(Base):
+class InvoicePayment(WorkspaceScoped, Base):
     __tablename__ = "invoice_payments"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -616,7 +667,7 @@ class InvoicePayment(Base):
     )
 
 
-class PaymentTaxAllocation(Base):
+class PaymentTaxAllocation(WorkspaceScoped, Base):
     __tablename__ = "payment_tax_allocations"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -633,7 +684,7 @@ class PaymentTaxAllocation(Base):
     payment: Mapped["InvoicePayment"] = relationship("InvoicePayment", back_populates="tax_allocations")
 
 
-class Settings(Base):
+class Settings(WorkspaceScoped, Base):
     __tablename__ = "settings"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -705,7 +756,7 @@ class Settings(Base):
     other_taxes: Mapped[list[dict] | None] = mapped_column(JSON, default=list)
 
 
-class TaxRateCatalog(Base):
+class TaxRateCatalog(WorkspaceScoped, Base):
     __tablename__ = "tax_rate_catalogs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
@@ -737,6 +788,9 @@ class User(Base):
 
     sessions: Mapped[list["UserSession"]] = relationship("UserSession", back_populates="user")
     expenses: Mapped[list["Expense"]] = relationship("Expense", back_populates="user")
+    workspace_memberships: Mapped[list["WorkspaceMembership"]] = relationship(
+        "WorkspaceMembership", back_populates="user", cascade="all, delete-orphan"
+    )
 
 
 class UserSession(Base):
@@ -744,8 +798,12 @@ class UserSession(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    active_workspace_id: Mapped[int | None] = mapped_column(
+        ForeignKey("workspaces.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     token_hash: Mapped[str] = mapped_column(String(128), unique=True, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     expires_at: Mapped[datetime] = mapped_column(DateTime)
 
     user: Mapped["User"] = relationship("User", back_populates="sessions")
+    active_workspace: Mapped["Workspace"] = relationship("Workspace")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -928,9 +928,63 @@ class UserOut(UserBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class WorkspaceOut(BaseModel):
+    id: int
+    name: str
+    slug: str
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class WorkspaceMembershipOut(BaseModel):
+    id: int
+    workspace_id: int
+    user_id: int
+    role: str
+    is_default: bool
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+    workspace: WorkspaceOut
+    user: UserOut
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class WorkspaceCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+    set_default: bool = True
+
+
+class WorkspaceUpdate(BaseModel):
+    name: str | None = None
+    is_active: bool | None = None
+
+
+class WorkspaceMembershipUpdate(BaseModel):
+    role: Literal["owner", "admin", "user"] | None = None
+    is_active: bool | None = None
+    is_default: bool | None = None
+
+
+class WorkspaceSwitchRequest(BaseModel):
+    workspace_id: int
+
+
+class WorkspaceSwitchResponse(BaseModel):
+    active_workspace: WorkspaceOut
+    membership_role: str
+
+
 class AuthStatus(BaseModel):
     needs_setup: bool
     user: Optional[UserOut] = None
+    active_workspace: WorkspaceOut | None = None
+    workspace_role: str | None = None
+    workspaces: list[WorkspaceMembershipOut] = []
 
 
 class EmailDraftResponse(BaseModel):
@@ -945,10 +999,16 @@ class EmailDraftResponse(BaseModel):
 class BackupRequest(BaseModel):
     download: bool = True
     store: bool = True
+    scope: Literal["workspace", "tenant"] = "workspace"
 
 
 class RestoreRequest(BaseModel):
     filename: str
+    workspace_name: str = Field(min_length=1, max_length=200)
+
+
+class ResetWorkspaceRequest(BaseModel):
+    workspace_name_confirm: str = Field(min_length=1, max_length=200)
 
 
 class SettingsBase(BaseModel):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -83,7 +83,21 @@ export default function App() {
     []
   );
 
-  const { user, needsSetup, loading, login, setup, logout } = useAuth();
+  const {
+    user,
+    activeWorkspace,
+    workspaceRole,
+    workspaces,
+    needsSetup,
+    loading,
+    login,
+    setup,
+    logout,
+    switchWorkspace,
+    createWorkspace,
+    setDefaultWorkspace,
+    updateWorkspace,
+  } = useAuth();
 
   const {
     clients,
@@ -281,9 +295,9 @@ export default function App() {
     setEditingUserId(null);
   };
 
-  const handleBackup = useCallback(async ({ download, store }) => {
+  const handleBackup = useCallback(async ({ download, store, scope = "workspace" }) => {
     try {
-      const response = await api.createBackup({ download, store });
+      const response = await api.createBackup({ download, store, scope });
       if (download && response?.blob) {
         const { blob, filename } = response;
         const url = URL.createObjectURL(blob);
@@ -340,9 +354,9 @@ export default function App() {
     resetQuoteForm,
   ]);
 
-  const handleResetWorkspace = useCallback(async () => {
+  const handleResetWorkspace = useCallback(async (workspaceNameConfirm) => {
     try {
-      await api.resetWorkspace();
+      await api.resetWorkspace(workspaceNameConfirm);
       handleSettingsSaved("Workspace reset. Reloading...");
       setTimeout(() => window.location.reload(), 800);
     } catch (error) {
@@ -360,9 +374,9 @@ export default function App() {
   }, [handleSettingsError]);
 
   const handleRestoreBackup = useCallback(
-    async (filename) => {
+    async (filename, workspaceName) => {
       try {
-        await api.restoreBackup(filename);
+        await api.restoreBackup(filename, workspaceName);
         handleSettingsSaved("Backup restored. Reloading...");
         setTimeout(() => window.location.reload(), 800);
       } catch (error) {
@@ -373,9 +387,9 @@ export default function App() {
   );
 
   const handleRestoreUpload = useCallback(
-    async (file) => {
+    async (file, workspaceName) => {
       try {
-        await api.restoreBackupUpload(file);
+        await api.restoreBackupUpload(file, workspaceName);
         handleSettingsSaved("Backup restored. Reloading...");
         setTimeout(() => window.location.reload(), 800);
       } catch (error) {
@@ -386,14 +400,15 @@ export default function App() {
   );
 
   const loadUsers = useCallback(async () => {
-    if (!user || user.role !== "owner") return;
+    const role = workspaceRole || user?.role;
+    if (!user || role !== "owner") return;
     try {
       const data = await api.listUsers();
       setUsers(data);
     } catch (error) {
       handleLoadError(error);
     }
-  }, [handleLoadError, user]);
+  }, [handleLoadError, user, workspaceRole]);
 
   const loadAssignableUsers = useCallback(async () => {
     if (!user) return;
@@ -406,12 +421,13 @@ export default function App() {
   }, [handleLoadError, user]);
 
   useEffect(() => {
-    if (user?.role === "owner") {
+    const role = workspaceRole || user?.role;
+    if (role === "owner") {
       loadUsers();
     } else {
       setUsers([]);
     }
-  }, [loadUsers, user]);
+  }, [loadUsers, workspaceRole, user?.role]);
 
   useEffect(() => {
     loadAssignableUsers();
@@ -1638,11 +1654,21 @@ export default function App() {
     );
   }
 
-  const canManageSettings = user.role !== "user";
+  const effectiveRole = workspaceRole || user.role;
+  const canManageSettings = effectiveRole !== "user";
 
   return (
     <AppShell
-      companyName={settings?.company_name || "Your Company"}
+      companyName={activeWorkspace?.name || settings?.company_name || "Your Company"}
+      workspaces={workspaces}
+      activeWorkspace={activeWorkspace}
+      onSwitchWorkspace={async (workspaceId) => {
+        await switchWorkspace(workspaceId);
+        await loadAll();
+      }}
+      onCreateWorkspace={createWorkspace}
+      onSetDefaultWorkspace={setDefaultWorkspace}
+      onUpdateWorkspace={updateWorkspace}
       navGroups={navGroups}
       view={view}
       navigateTo={navigateTo}
@@ -1652,7 +1678,7 @@ export default function App() {
       formatFinancialYearLabel={formatFinancialYearLabel}
       logout={logout}
       canManageSettings={canManageSettings}
-      isOwner={user?.role === "owner"}
+      isOwner={effectiveRole === "owner"}
       userEmail={user?.email}
     >
       <div className="app-view-transition" data-nav-direction={navDirection}>
@@ -1843,6 +1869,7 @@ export default function App() {
         {view === VIEWS.SETTINGS && canManageSettings && (
           <SettingsPage
             settings={settings}
+            activeWorkspaceName={activeWorkspace?.name || settings?.company_name || "Workspace"}
             updateSettings={updateSettings}
             onSaveSettings={saveSettings}
             onSaveSmtp={saveSettings}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -281,7 +281,7 @@ const api = {
       method: "POST",
       body: JSON.stringify({ log_ids: logIds }),
     }),
-  createBackup: async ({ download = true, store = true } = {}) => {
+  createBackup: async ({ download = true, store = true, scope = "workspace" } = {}) => {
     if (download) {
       let response;
       try {
@@ -289,7 +289,7 @@ const api = {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ download, store }),
+          body: JSON.stringify({ download, store, scope }),
         });
       } catch (error) {
         throw normalizeFetchError(error);
@@ -307,25 +307,53 @@ const api = {
 
     return request("/admin/backup", {
       method: "POST",
-      body: JSON.stringify({ download, store }),
+      body: JSON.stringify({ download, store, scope }),
     });
   },
   listBackups: () => request("/admin/backups"),
-  restoreBackup: (filename) =>
-    request("/admin/restore", { method: "POST", body: JSON.stringify({ filename }) }),
-  restoreBackupUpload: (file) => {
+  restoreBackup: (filename, workspaceName) =>
+    request("/admin/restore", {
+      method: "POST",
+      body: JSON.stringify({ filename, workspace_name: workspaceName }),
+    }),
+  restoreBackupUpload: (file, workspaceName) => {
     const formData = new FormData();
     formData.append("file", file);
+    formData.append("workspace_name", workspaceName);
     return requestForm("/admin/restore/upload", formData);
   },
   resetData: () => request("/admin/reset", { method: "POST" }),
-  resetWorkspace: () => request("/admin/reset-workspace", { method: "POST" }),
+  resetWorkspace: (workspaceNameConfirm) =>
+    request("/admin/reset-workspace", {
+      method: "POST",
+      body: JSON.stringify({ workspace_name_confirm: workspaceNameConfirm }),
+    }),
   authStatus: () => request("/auth/status"),
   authLogin: (payload) =>
     request("/auth/login", { method: "POST", body: JSON.stringify(payload) }),
   authSetup: (payload) =>
     request("/auth/setup", { method: "POST", body: JSON.stringify(payload) }),
   authLogout: () => request("/auth/logout", { method: "POST" }),
+  listWorkspaces: () => request("/workspaces"),
+  createWorkspace: (payload) =>
+    request("/workspaces", { method: "POST", body: JSON.stringify(payload) }),
+  updateWorkspace: (id, payload) =>
+    request(`/workspaces/${id}`, { method: "PATCH", body: JSON.stringify(payload) }),
+  switchWorkspace: (workspaceId) =>
+    request("/workspaces/switch", {
+      method: "POST",
+      body: JSON.stringify({ workspace_id: workspaceId }),
+    }),
+  setDefaultWorkspace: (workspaceId) =>
+    request(`/workspaces/${workspaceId}/set-default`, { method: "POST" }),
+  listWorkspaceMembers: (workspaceId) => request(`/workspaces/${workspaceId}/members`),
+  updateWorkspaceMember: (workspaceId, userId, payload) =>
+    request(`/workspaces/${workspaceId}/members/${userId}`, {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    }),
+  deleteWorkspaceMember: (workspaceId, userId) =>
+    request(`/workspaces/${workspaceId}/members/${userId}`, { method: "DELETE" }),
   listUsers: () => request("/auth/users"),
   listAssignableUsers: () => request("/auth/users/assignable"),
   searchUsers: (query) => request(`/auth/users/search?q=${encodeURIComponent(query)}`),

--- a/frontend/src/components/app-shell.jsx
+++ b/frontend/src/components/app-shell.jsx
@@ -4,6 +4,12 @@ import { Toaster } from "@/components/ui/sonner";
 
 export default function AppShell({
   companyName,
+  workspaces,
+  activeWorkspace,
+  onSwitchWorkspace,
+  onCreateWorkspace,
+  onSetDefaultWorkspace,
+  onUpdateWorkspace,
   navGroups,
   view,
   navigateTo,
@@ -23,6 +29,12 @@ export default function AppShell({
         <Toaster position="top-right" theme="system" richColors />
         <AppSidebar
           companyName={companyName}
+          workspaces={workspaces}
+          activeWorkspace={activeWorkspace}
+          onSwitchWorkspace={onSwitchWorkspace}
+          onCreateWorkspace={onCreateWorkspace}
+          onSetDefaultWorkspace={onSetDefaultWorkspace}
+          onUpdateWorkspace={onUpdateWorkspace}
           navGroups={navGroups}
           view={view}
           setView={navigateTo}
@@ -46,4 +58,3 @@ export default function AppShell({
     </SidebarProvider>
   );
 }
-

--- a/frontend/src/components/app-sidebar.jsx
+++ b/frontend/src/components/app-sidebar.jsx
@@ -25,6 +25,12 @@ import {
 
 export function AppSidebar({
   companyName,
+  workspaces,
+  activeWorkspace,
+  onSwitchWorkspace,
+  onCreateWorkspace,
+  onSetDefaultWorkspace,
+  onUpdateWorkspace,
   navGroups,
   view,
   setView,
@@ -39,14 +45,26 @@ export function AppSidebar({
   ...props
 }) {
   const teams = React.useMemo(
-    () => [
-      {
-        name: companyName || "Workspace",
+    () => {
+      const mapped = (workspaces || []).map((membership) => ({
+        id: membership.workspace.id,
+        name: membership.workspace.name || companyName || "Workspace",
         logo: Building2,
-        plan: "Workspace",
-      },
-    ],
-    [companyName]
+        plan: membership.role || "Workspace",
+        isDefault: Boolean(membership.is_default),
+      }));
+      if (mapped.length) return mapped;
+      return [
+        {
+          id: 0,
+          name: companyName || "Workspace",
+          logo: Building2,
+          plan: "Workspace",
+          isDefault: true,
+        },
+      ];
+    },
+    [companyName, workspaces]
   );
 
   const iconMap = {
@@ -67,7 +85,14 @@ export function AppSidebar({
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
-        <TeamSwitcher teams={teams} />
+        <TeamSwitcher
+          teams={teams}
+          activeTeamId={activeWorkspace?.id}
+          onTeamSwitch={onSwitchWorkspace}
+          onCreateTeam={onCreateWorkspace}
+          onSetDefaultTeam={onSetDefaultWorkspace}
+          onUpdateTeam={onUpdateWorkspace}
+        />
         <div className={isCollapsed ? "pb-2" : "px-2 pb-2"}>
           <Select value={selectedYear} onValueChange={setSelectedYear}>
             {isCollapsed ? (

--- a/frontend/src/components/team-switcher.jsx
+++ b/frontend/src/components/team-switcher.jsx
@@ -1,6 +1,18 @@
-import * as React from "react"
-import { ChevronsUpDown, Plus } from "lucide-react"
+import * as React from "react";
+import { ChevronsUpDown, Plus } from "lucide-react";
+import { toast } from "sonner";
 
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -9,31 +21,132 @@ import {
   DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
   useSidebar,
-} from "@/components/ui/sidebar"
+} from "@/components/ui/sidebar";
 
 export function TeamSwitcher({
-  teams
+  teams = [],
+  activeTeamId,
+  onTeamSwitch,
+  onCreateTeam,
+  onSetDefaultTeam,
+  onUpdateTeam,
 }) {
-  const { isMobile } = useSidebar()
-  const [activeTeam, setActiveTeam] = React.useState(teams[0])
+  const { isMobile } = useSidebar();
+  const [activeTeam, setActiveTeam] = React.useState(teams[0]);
+  const [createOpen, setCreateOpen] = React.useState(false);
+  const [workspaceName, setWorkspaceName] = React.useState("");
+  const [renameValue, setRenameValue] = React.useState("");
+  const [renameOpen, setRenameOpen] = React.useState(false);
+  const [setDefault, setSetDefault] = React.useState(true);
+  const [saving, setSaving] = React.useState(false);
+  const isMac = React.useMemo(
+    () => typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform),
+    []
+  );
 
   React.useEffect(() => {
-    if (!teams?.length) return
+    if (!teams?.length) return;
+    if (activeTeamId) {
+      const exact = teams.find((team) => team.id === activeTeamId);
+      if (exact) {
+        setActiveTeam(exact);
+        return;
+      }
+    }
     setActiveTeam((prev) => {
-      if (!prev) return teams[0]
-      const match = teams.find((team) => team.name === prev.name)
-      return match || teams[0]
-    })
-  }, [teams])
+      if (!prev) return teams[0];
+      const match = teams.find((team) => team.id === prev.id);
+      return match || teams[0];
+    });
+  }, [teams, activeTeamId]);
+
+  const handleSwitch = async (team) => {
+    try {
+      if (onTeamSwitch) {
+        await onTeamSwitch(team.id);
+      }
+      setActiveTeam(team);
+      toast.success(`Switched to ${team.name}.`);
+    } catch (error) {
+      toast.error(error.message || "Unable to switch workspace.");
+    }
+  };
+
+  const handleCreateWorkspace = async () => {
+    const nextName = workspaceName.trim();
+    if (!nextName) {
+      toast.error("Workspace name is required.");
+      return;
+    }
+    try {
+      setSaving(true);
+      await onCreateTeam?.({ name: nextName, set_default: setDefault });
+      setWorkspaceName("");
+      setSetDefault(true);
+      setCreateOpen(false);
+      toast.success("Workspace created.");
+    } catch (error) {
+      toast.error(error.message || "Unable to create workspace.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSetDefault = async (team) => {
+    try {
+      await onSetDefaultTeam?.(team.id);
+      toast.success(`${team.name} is now your default workspace.`);
+    } catch (error) {
+      toast.error(error.message || "Unable to set default workspace.");
+    }
+  };
+
+  React.useEffect(() => {
+    const onKeyDown = (event) => {
+      const tag = (event.target?.tagName || "").toLowerCase();
+      if (tag === "input" || tag === "textarea" || event.target?.isContentEditable) {
+        return;
+      }
+      const match = /^Digit([1-9])$/.exec(event.code || "");
+      if (!match) return;
+      const index = Number(match[1]) - 1;
+      const target = teams[index];
+      if (!target) return;
+      const usesShortcut = isMac
+        ? event.altKey && event.shiftKey && !event.metaKey && !event.ctrlKey
+        : event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
+      if (!usesShortcut) return;
+      event.preventDefault();
+      handleSwitch(target);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isMac, teams]);
+
+  const handleRenameWorkspace = async () => {
+    const nextName = renameValue.trim();
+    if (!activeTeam?.id || !nextName) return;
+    try {
+      setSaving(true);
+      await onUpdateTeam?.(activeTeam.id, { name: nextName });
+      setRenameOpen(false);
+      toast.success("Workspace renamed.");
+    } catch (error) {
+      toast.error(error.message || "Unable to rename workspace.");
+    } finally {
+      setSaving(false);
+    }
+  };
 
   if (!activeTeam) {
-    return null
+    return null;
   }
 
   return (
@@ -43,37 +156,138 @@ export function TeamSwitcher({
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
               size="lg"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground">
-              <div
-                className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
                 <activeTeam.logo className="size-4" />
               </div>
               <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-semibold">
-                  {activeTeam.name}
-                </span>
-                <span className="truncate text-xs">{activeTeam.plan}</span>
+                <span className="truncate font-semibold">{activeTeam.name}</span>
+                <span className="truncate text-xs capitalize">{activeTeam.plan}</span>
               </div>
               <ChevronsUpDown className="ml-auto" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+            className="w-[max(20rem,var(--radix-dropdown-menu-trigger-width))] max-w-[26rem] rounded-lg"
             align="start"
             side={isMobile ? "bottom" : "right"}
-            sideOffset={4}>
+            sideOffset={4}
+          >
             <DropdownMenuLabel className="text-xs text-muted-foreground">
               Workspaces
             </DropdownMenuLabel>
             {teams.map((team, index) => (
-              <DropdownMenuItem key={team.name} onClick={() => setActiveTeam(team)} className="gap-2 p-2">
+              <DropdownMenuItem key={team.id} onClick={() => handleSwitch(team)} className="gap-2 p-2">
                 <div className="flex size-6 items-center justify-center rounded-sm border">
                   <team.logo className="size-4 shrink-0" />
                 </div>
-                {team.name}
-                <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
+                <span className="min-w-0 flex-1 truncate">{team.name}</span>
+                <DropdownMenuShortcut>{isMac ? `⌥⇧${index + 1}` : `Ctrl+Shift+${index + 1}`}</DropdownMenuShortcut>
               </DropdownMenuItem>
             ))}
+            <DropdownMenuSeparator />
+            <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+              <DialogTrigger asChild>
+                <DropdownMenuItem
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    setRenameValue(activeTeam.name || "");
+                  }}
+                  className="gap-2 p-2"
+                >
+                  Rename active workspace
+                </DropdownMenuItem>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                  <DialogTitle>Rename workspace</DialogTitle>
+                  <DialogDescription>
+                    Update the workspace display name used across this context.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-2">
+                  <label className="text-sm font-medium text-foreground">Workspace name</label>
+                  <Input
+                    className="w-full"
+                    value={renameValue}
+                    onChange={(event) => setRenameValue(event.target.value)}
+                  />
+                </div>
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={() => setRenameOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button type="button" onClick={handleRenameWorkspace} disabled={saving}>
+                    {saving ? "Saving..." : "Save"}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+            <DropdownMenuItem
+              onSelect={(event) => event.preventDefault()}
+              onClick={() => {
+                if (activeTeam && !activeTeam.isDefault) {
+                  handleSetDefault(activeTeam);
+                }
+              }}
+              className="gap-2"
+            >
+              <Checkbox
+                checked={Boolean(activeTeam?.isDefault)}
+                className="my-auto"
+                aria-label="Set active workspace as default"
+              />
+              <span className="my-auto">Set active workspace as default</span>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+              <DialogTrigger asChild>
+                <DropdownMenuItem
+                  onSelect={(event) => event.preventDefault()}
+                  className="gap-2 p-2"
+                >
+                  <div className="flex size-6 items-center justify-center rounded-md border bg-background">
+                    <Plus className="size-4" />
+                  </div>
+                  <div className="font-medium text-muted-foreground">Create workspace</div>
+                </DropdownMenuItem>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                  <DialogTitle>Create workspace</DialogTitle>
+                  <DialogDescription>
+                    Create a separate business workspace and optionally set it as default.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-4">
+                  <div className="grid gap-2">
+                    <label className="text-sm font-medium text-foreground">Workspace name</label>
+                    <Input
+                      className="w-full"
+                      value={workspaceName}
+                      onChange={(event) => setWorkspaceName(event.target.value)}
+                      placeholder="e.g. 704 Consultancy (Client B)"
+                    />
+                  </div>
+                  <label className="flex min-h-10 items-center gap-2 rounded-md border border-border px-3 text-sm">
+                    <Checkbox
+                      checked={setDefault}
+                      onCheckedChange={(value) => setSetDefault(value === true)}
+                    />
+                    Set as default workspace
+                  </label>
+                </div>
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button type="button" onClick={handleCreateWorkspace} disabled={saving}>
+                    {saving ? "Creating..." : "Create workspace"}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
           </DropdownMenuContent>
         </DropdownMenu>
       </SidebarMenuItem>

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -3,6 +3,9 @@ import { api } from "@/api/client";
 
 const useAuth = () => {
   const [user, setUser] = useState(null);
+  const [activeWorkspace, setActiveWorkspace] = useState(null);
+  const [workspaceRole, setWorkspaceRole] = useState(null);
+  const [workspaces, setWorkspaces] = useState([]);
   const [needsSetup, setNeedsSetup] = useState(false);
   const [loading, setLoading] = useState(true);
 
@@ -12,6 +15,9 @@ const useAuth = () => {
       const status = await api.authStatus();
       setNeedsSetup(Boolean(status.needs_setup));
       setUser(status.user || null);
+      setActiveWorkspace(status.active_workspace || null);
+      setWorkspaceRole(status.workspace_role || null);
+      setWorkspaces(status.workspaces || []);
     } finally {
       setLoading(false);
     }
@@ -21,6 +27,9 @@ const useAuth = () => {
     const status = await api.authLogin(payload);
     setNeedsSetup(Boolean(status.needs_setup));
     setUser(status.user || null);
+    setActiveWorkspace(status.active_workspace || null);
+    setWorkspaceRole(status.workspace_role || null);
+    setWorkspaces(status.workspaces || []);
     return status;
   }, []);
 
@@ -28,13 +37,39 @@ const useAuth = () => {
     const status = await api.authSetup(payload);
     setNeedsSetup(Boolean(status.needs_setup));
     setUser(status.user || null);
+    setActiveWorkspace(status.active_workspace || null);
+    setWorkspaceRole(status.workspace_role || null);
+    setWorkspaces(status.workspaces || []);
     return status;
   }, []);
 
   const logout = useCallback(async () => {
     await api.authLogout();
     setUser(null);
+    setActiveWorkspace(null);
+    setWorkspaceRole(null);
+    setWorkspaces([]);
   }, []);
+
+  const switchWorkspace = useCallback(async (workspaceId) => {
+    await api.switchWorkspace(workspaceId);
+    await refreshStatus();
+  }, [refreshStatus]);
+
+  const createWorkspace = useCallback(async (payload) => {
+    await api.createWorkspace(payload);
+    await refreshStatus();
+  }, [refreshStatus]);
+
+  const setDefaultWorkspace = useCallback(async (workspaceId) => {
+    await api.setDefaultWorkspace(workspaceId);
+    await refreshStatus();
+  }, [refreshStatus]);
+
+  const updateWorkspace = useCallback(async (workspaceId, payload) => {
+    await api.updateWorkspace(workspaceId, payload);
+    await refreshStatus();
+  }, [refreshStatus]);
 
   useEffect(() => {
     refreshStatus();
@@ -42,11 +77,18 @@ const useAuth = () => {
 
   return {
     user,
+    activeWorkspace,
+    workspaceRole,
+    workspaces,
     needsSetup,
     loading,
     login,
     setup,
     logout,
+    switchWorkspace,
+    createWorkspace,
+    setDefaultWorkspace,
+    updateWorkspace,
     refreshStatus,
   };
 };

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -30,6 +30,7 @@ import { useState } from "react";
 
 export default function SettingsPage({
   settings,
+  activeWorkspaceName = "Workspace",
   updateSettings,
   onSaveSettings,
   onSaveSmtp,
@@ -46,15 +47,18 @@ export default function SettingsPage({
   const [backupDialogOpen, setBackupDialogOpen] = useState(false);
   const [backupDownload, setBackupDownload] = useState(true);
   const [backupStore, setBackupStore] = useState(true);
+  const [backupScope, setBackupScope] = useState("workspace");
   const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
   const [restoreConfirm, setRestoreConfirm] = useState("");
+  const [restoreWorkspaceName, setRestoreWorkspaceName] = useState("");
   const [backups, setBackups] = useState([]);
   const [selectedBackup, setSelectedBackup] = useState("");
   const [restoreFile, setRestoreFile] = useState(null);
   const companyName = settings?.company_name || "Your Company";
+  const workspaceName = activeWorkspaceName || "Workspace";
   const canReset = resetConfirm.trim() === companyName.trim();
-  const canResetWorkspace = workspaceConfirm.trim() === companyName.trim();
-  const canRestore = restoreConfirm.trim() === companyName.trim();
+  const canResetWorkspace = workspaceConfirm.trim() === workspaceName.trim();
+  const canRestore = restoreConfirm.trim() === companyName.trim() && restoreWorkspaceName.trim().length > 0;
   const canBackup = backupDownload || backupStore;
 
   return (
@@ -399,177 +403,17 @@ export default function SettingsPage({
           <CardTitle>Danger zone</CardTitle>
           <CardDescription>Actions that affect data integrity.</CardDescription>
         </CardHeader>
-        <CardContent className="space-y-3">
-            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-              <div>
-                <p className="font-medium text-foreground">Download backup</p>
-                <p className="text-sm text-muted-foreground">
-                  Creates a tar.gz of the database and uploads.
-                </p>
-              </div>
-            <Dialog open={backupDialogOpen} onOpenChange={setBackupDialogOpen}>
-              <DialogTrigger asChild>
-                <Button variant="outline">Create backup</Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Create backup</DialogTitle>
-                  <DialogDescription>
-                    Choose whether to download the backup now and/or store it on the server for later restore.
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <p className="font-medium text-foreground">Download now</p>
-                      <p className="text-sm text-muted-foreground">
-                        Exports a tar.gz to your device.
-                      </p>
-                    </div>
-                    <Switch checked={backupDownload} onCheckedChange={setBackupDownload} />
-                  </div>
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <p className="font-medium text-foreground">Store on server</p>
-                      <p className="text-sm text-muted-foreground">
-                        Saves a copy in the server backups folder.
-                      </p>
-                    </div>
-                    <Switch checked={backupStore} onCheckedChange={setBackupStore} />
-                  </div>
-                  {!canBackup && (
-                    <p className="text-sm text-destructive">
-                      Select at least one option.
-                    </p>
-                  )}
-                </div>
-                <DialogFooter>
-                  <Button
-                    variant="outline"
-                    onClick={() => setBackupDialogOpen(false)}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    onClick={() => {
-                      if (!canBackup) return;
-                      onBackup({ download: backupDownload, store: backupStore });
-                      setBackupDialogOpen(false);
-                    }}
-                    disabled={!canBackup}
-                  >
-                    Run backup
-                  </Button>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-          </div>
-          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-            <div>
-              <p className="font-medium text-foreground">Restore backup</p>
-              <p className="text-sm text-muted-foreground">
-                Restore from a server backup or upload a tar.gz file.
-              </p>
-            </div>
-            <Dialog
-              open={restoreDialogOpen}
-              onOpenChange={(open) => {
-                setRestoreDialogOpen(open);
-                if (open && onListBackups) {
-                  onListBackups().then((list) => {
-                    const items = list?.backups || [];
-                    setBackups(items);
-                    setSelectedBackup(items[0] || "");
-                  });
-                }
-              }}
-            >
-              <DialogTrigger asChild>
-                <Button variant="outline">Restore backup</Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Restore backup</DialogTitle>
-                  <DialogDescription>
-                    Restoring will replace the current business data and uploads. To confirm, type{" "}
-                    <strong>{companyName}</strong> below. The app will reload after completion.
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-4">
-                  <div className="space-y-2">
-                    <Input
-                      value={restoreConfirm}
-                      onChange={(event) => setRestoreConfirm(event.target.value)}
-                      placeholder={companyName}
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      The company name must match exactly.
-                    </p>
-                  </div>
-                  <div className="space-y-2">
-                    <p className="text-sm font-medium text-foreground">Restore from server</p>
-                    <Select value={selectedBackup} onValueChange={setSelectedBackup}>
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Select backup file" />
-                    </SelectTrigger>
-                      <SelectContent>
-                        {backups.length === 0 && (
-                          <SelectItem value="none" disabled>
-                            No backups found
-                          </SelectItem>
-                        )}
-                        {backups.map((item) => (
-                          <SelectItem key={item} value={item}>
-                            {item}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <Button
-                      variant="secondary"
-                      onClick={() => {
-                        if (!canRestore || !selectedBackup || selectedBackup === "none") return;
-                        onRestoreBackup(selectedBackup);
-                        setRestoreDialogOpen(false);
-                      }}
-                      disabled={!canRestore || !selectedBackup || selectedBackup === "none"}
-                    >
-                      Restore selected
-                    </Button>
-                  </div>
-                  <div className="space-y-2">
-                    <p className="text-sm font-medium text-foreground">Restore from upload</p>
-                    <Input
-                      type="file"
-                      accept=".tar.gz"
-                      onChange={(event) => setRestoreFile(event.target.files?.[0] || null)}
-                    />
-                    <Button
-                      variant="secondary"
-                      onClick={() => {
-                        if (!canRestore || !restoreFile) return;
-                        onRestoreUpload(restoreFile);
-                        setRestoreDialogOpen(false);
-                      }}
-                      disabled={!canRestore || !restoreFile}
-                    >
-                      Restore uploaded
-                    </Button>
-                  </div>
-                </div>
-                <DialogFooter>
-                  <Button variant="outline" onClick={() => setRestoreDialogOpen(false)}>
-                    Close
-                  </Button>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-          </div>
+        <CardContent className="space-y-4">
+          <div className="rounded-md border border-destructive/20 p-4 space-y-3">
+            <h3 className="text-sm font-semibold text-foreground">Workspace danger</h3>
+            <p className="text-xs text-muted-foreground">
+              Applies only to <strong>{workspaceName}</strong>.
+            </p>
           <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
             <div>
               <p className="font-medium text-foreground">Reset business data</p>
               <p className="text-sm text-muted-foreground">
-                Deletes clients, invoices, quotes, agreements, proposals, expenses, and uploads. Users and settings remain.
+                Deletes business records and uploads for the active workspace only.
               </p>
             </div>
             <AlertDialog>
@@ -605,41 +449,237 @@ export default function SettingsPage({
           </div>
           <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
             <div>
-              <p className="font-medium text-foreground">Reset workspace</p>
+              <p className="font-medium text-foreground">Delete workspace</p>
               <p className="text-sm text-muted-foreground">
-                Deletes all business data, settings, and users. You will need to run the setup wizard again.
+                Permanently deletes the active workspace data and uploads. Other workspaces remain intact.
               </p>
             </div>
             <AlertDialog>
               <AlertDialogTrigger asChild>
-                <Button variant="destructive">Reset workspace</Button>
+                <Button variant="destructive">Delete workspace</Button>
               </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
-                  <AlertDialogTitle>Reset the entire workspace?</AlertDialogTitle>
+                  <AlertDialogTitle>Delete this workspace?</AlertDialogTitle>
                   <AlertDialogDescription>
-                    This action is irreversible. It will remove all business data, settings, and user accounts.
-                    To confirm, type <strong>{companyName}</strong> below.
+                    This action is irreversible. It will remove this workspace data and uploads only.
+                    To confirm, type <strong>{workspaceName}</strong> below.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <div className="space-y-2">
+                  <label className={labelClass}>Workspace name confirmation</label>
                   <Input
                     value={workspaceConfirm}
                     onChange={(event) => setWorkspaceConfirm(event.target.value)}
-                    placeholder={companyName}
+                    placeholder={workspaceName}
                   />
                   <p className="text-xs text-muted-foreground">
-                    The company name must match exactly.
+                    The active workspace name must match exactly.
                   </p>
                 </div>
                 <AlertDialogFooter>
                   <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction onClick={onResetWorkspace} disabled={!canResetWorkspace}>
-                    Yes, reset workspace
+                  <AlertDialogAction
+                    onClick={() => onResetWorkspace(workspaceConfirm.trim())}
+                    disabled={!canResetWorkspace}
+                  >
+                    Yes, delete workspace
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>
+          </div>
+          </div>
+
+          <div className="rounded-md border border-destructive/20 p-4 space-y-3">
+            <h3 className="text-sm font-semibold text-foreground">System danger</h3>
+            <p className="text-xs text-muted-foreground">
+              Operations affecting backup/restore at tenant level.
+            </p>
+            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="font-medium text-foreground">Create backup</p>
+                <p className="text-sm text-muted-foreground">
+                  Choose backup scope: active workspace only, or entire tenant.
+                </p>
+              </div>
+              <Dialog open={backupDialogOpen} onOpenChange={setBackupDialogOpen}>
+                <DialogTrigger asChild>
+                  <Button variant="outline">Create backup</Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Create backup</DialogTitle>
+                    <DialogDescription>
+                      Choose backup scope and whether to download/store.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className="space-y-3">
+                    <div className="space-y-2">
+                      <label className={labelClass}>Backup scope</label>
+                      <Select value={backupScope} onValueChange={setBackupScope}>
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Select scope" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="workspace">Active workspace only</SelectItem>
+                          <SelectItem value="tenant">Entire tenant (all workspaces)</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <p className="font-medium text-foreground">Download now</p>
+                        <p className="text-sm text-muted-foreground">
+                          Exports a tar.gz to your device.
+                        </p>
+                      </div>
+                      <Switch checked={backupDownload} onCheckedChange={setBackupDownload} />
+                    </div>
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <p className="font-medium text-foreground">Store on server</p>
+                        <p className="text-sm text-muted-foreground">
+                          Saves a copy in the server backups folder.
+                        </p>
+                      </div>
+                      <Switch checked={backupStore} onCheckedChange={setBackupStore} />
+                    </div>
+                    {!canBackup && (
+                      <p className="text-sm text-destructive">
+                        Select at least one option.
+                      </p>
+                    )}
+                  </div>
+                  <DialogFooter>
+                    <Button variant="outline" onClick={() => setBackupDialogOpen(false)}>
+                      Cancel
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        if (!canBackup) return;
+                        onBackup({ download: backupDownload, store: backupStore, scope: backupScope });
+                        setBackupDialogOpen(false);
+                      }}
+                      disabled={!canBackup}
+                    >
+                      Run backup
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </div>
+            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="font-medium text-foreground">Restore backup</p>
+                <p className="text-sm text-muted-foreground">
+                  Restore from a server backup or upload a tar.gz file.
+                </p>
+              </div>
+            <Dialog
+              open={restoreDialogOpen}
+              onOpenChange={(open) => {
+                setRestoreDialogOpen(open);
+                if (open && onListBackups) {
+                  onListBackups().then((list) => {
+                    const items = list?.backups || [];
+                    setBackups(items);
+                    setSelectedBackup(items[0] || "");
+                  });
+                }
+              }}
+            >
+              <DialogTrigger asChild>
+                <Button variant="outline">Restore backup</Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Restore backup</DialogTitle>
+                  <DialogDescription>
+                    Restoring will replace current tenant data and uploads with backup contents. To confirm, type{" "}
+                    <strong>{companyName}</strong> and provide the restored workspace name.
+                    The app will reload after completion.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <label className={labelClass}>Restored workspace name</label>
+                    <Input
+                      value={restoreWorkspaceName}
+                      onChange={(event) => setRestoreWorkspaceName(event.target.value)}
+                      placeholder="e.g. Client B (Restored)"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className={labelClass}>Confirmation</label>
+                    <Input
+                      value={restoreConfirm}
+                      onChange={(event) => setRestoreConfirm(event.target.value)}
+                      placeholder={companyName}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      The company name must match exactly.
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-foreground">Restore from server</p>
+                    <Select value={selectedBackup} onValueChange={setSelectedBackup}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Select backup file" />
+                    </SelectTrigger>
+                      <SelectContent>
+                        {backups.length === 0 && (
+                          <SelectItem value="none" disabled>
+                            No backups found
+                          </SelectItem>
+                        )}
+                        {backups.map((item) => (
+                          <SelectItem key={item} value={item}>
+                            {item}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      variant="secondary"
+                      onClick={() => {
+                        if (!canRestore || !selectedBackup || selectedBackup === "none") return;
+                        onRestoreBackup(selectedBackup, restoreWorkspaceName.trim());
+                        setRestoreDialogOpen(false);
+                      }}
+                      disabled={!canRestore || !selectedBackup || selectedBackup === "none"}
+                    >
+                      Restore selected
+                    </Button>
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-foreground">Restore from upload</p>
+                    <Input
+                      type="file"
+                      accept=".tar.gz"
+                      onChange={(event) => setRestoreFile(event.target.files?.[0] || null)}
+                    />
+                    <Button
+                      variant="secondary"
+                      onClick={() => {
+                        if (!canRestore || !restoreFile) return;
+                        onRestoreUpload(restoreFile, restoreWorkspaceName.trim());
+                        setRestoreDialogOpen(false);
+                      }}
+                      disabled={!canRestore || !restoreFile}
+                    >
+                      Restore uploaded
+                    </Button>
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setRestoreDialogOpen(false)}>
+                    Close
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </div>
           </div>
         </CardContent>
       </Card>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -59,6 +59,10 @@ export default defineConfig({
         target: "http://127.0.0.1:8000",
         changeOrigin: true,
       },
+      "/workspaces": {
+        target: "http://127.0.0.1:8000",
+        changeOrigin: true,
+      },
       "/health": {
         target: "http://127.0.0.1:8000",
         changeOrigin: true,


### PR DESCRIPTION
## Summary
Implements strict multi-workspace tenancy for a single account, including backend isolation, session-bound workspace context, workspace switching/management, and workspace-safe admin operations. Also updates Danger Zone UX to separate workspace vs system actions and adds backup scope selection (workspace-only vs tenant-wide).

## What Changed

### Backend: Workspace tenancy foundation
- Added first-class workspace models:
  - `workspaces`
  - `workspace_memberships` (per-workspace role + default workspace)
- Added `workspace_id` to workspace-owned entities via model updates.
- Added `active_workspace_id` to `user_sessions`.
- Added migration to:
  - create workspace tables
  - backfill existing data into bootstrap workspace
  - backfill memberships
  - attach workspace context to existing data/sessions
  - add SQLite cross-workspace integrity triggers

### Backend: Auth/session + request scoping
- Added workspace context resolution on authenticated requests.
- Added `require_workspace_context` dependency.
- Updated role checks to use membership role in workspace context.
- Added global ORM workspace scoping hooks in DB session layer.
- Auto-populates `workspace_id` on new scoped rows when context exists.

### Backend: Workspace APIs
- Added:
  - `GET /workspaces`
  - `POST /workspaces`
  - `PATCH /workspaces/{workspace_id}`
  - `POST /workspaces/switch`
  - `POST /workspaces/{workspace_id}/set-default`
  - `GET /workspaces/{workspace_id}/members`
  - `PUT /workspaces/{workspace_id}/members/{user_id}`
  - `DELETE /workspaces/{workspace_id}/members/{user_id}`
- Extended auth status response with:
  - `active_workspace`
  - `workspace_role`
  - `workspaces[]`

### Backend: Backup/restore and danger-zone hardening
- Backup now supports scope:
  - `workspace` (active workspace only)
  - `tenant` (all workspaces)
- Backup filenames include scope and timestamp.
- Backup snapshot now uses SQLite backup API for safer snapshots.
- Workspace-scoped backups include only workspace data + referenced uploads.
- Restore now requires desired workspace name.
- Delete workspace now requires exact typed workspace name confirmation.
- Delete workspace blocks deleting the last remaining workspace.
- Reset data/delete workspace now remove only workspace-referenced uploads (no global upload wipe).

### Frontend: Workspace UX + state
- Wired Team Switcher to real workspace APIs (switch/create/rename/default).
- Improved switcher UX:
  - wider/clamped popover
  - browser-safe shortcuts (no Safari `Cmd+1` conflict)
  - default workspace control moved to explicit option under rename area
- Added workspace context to app auth state and shell props.
- Added `/workspaces` proxy route in Vite for local dev.

### Frontend: Danger Zone redesign
- Split into:
  - `Workspace danger`
  - `System danger`
- Added backup scope selector in Create Backup dialog:
  - `Active workspace only`
  - `Entire tenant (all workspaces)`
- Updated delete workspace confirmation to typed workspace name.
- Restore requires typed workspace name.

## Files
- Backend:
  - `backend/app/models.py`
  - `backend/app/db.py`
  - `backend/app/auth.py`
  - `backend/app/crud.py`
  - `backend/app/main.py`
  - `backend/app/schemas.py`
  - `backend/alembic/versions/a7c3d1f9b2aa_add_workspaces_multitenancy.py`
- Frontend:
  - `frontend/src/hooks/useAuth.js`
  - `frontend/src/api/client.js`
  - `frontend/src/App.jsx`
  - `frontend/src/components/app-shell.jsx`
  - `frontend/src/components/app-sidebar.jsx`
  - `frontend/src/components/team-switcher.jsx`
  - `frontend/src/pages/SettingsPage.jsx`
  - `frontend/vite.config.js`

## Validation
- Backend compile checks passed:
  - `python -m py_compile app/main.py app/auth.py app/crud.py app/models.py app/schemas.py app/db.py`
- Alembic migration applied:
  - `alembic upgrade head`
- Frontend build passed:
  - `npm run build`

## QA Checklist
- [x] Login returns active workspace and workspace list.
- [x] Team switcher switches context and reloads data correctly.
- [x] Create/rename/set-default workspace actions work.
- [x] Data in each workspace remains isolated.
- [x] Workspace backup contains only selected workspace data/uploads.
- [x] Tenant backup contains all workspace data/uploads.
- [x] Restore requires workspace name and succeeds.
- [x] Delete workspace requires exact typed name and does not affect other workspaces.
- [x] Reset data affects only active workspace.
- [x] Local dev `/workspaces` requests proxy correctly.
