### PR TITLE
feat(tax,dashboard): filing bundle zip export, FY checklist persisten…

### DIFF
--- a/backend/alembic/versions/d4a9f8b1c2e3_add_filing_checklist_state_to_settings.py
+++ b/backend/alembic/versions/d4a9f8b1c2e3_add_filing_checklist_state_to_settings.py
@@ -1,0 +1,35 @@
+"""add filing checklist state to settings
+
+Revision ID: d4a9f8b1c2e3
+Revises: a7c3d1f9b2aa
+Create Date: 2026-04-05 12:40:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d4a9f8b1c2e3"
+down_revision: Union[str, None] = "a7c3d1f9b2aa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("settings", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "filing_checklist_state",
+                sa.JSON(),
+                nullable=True,
+                server_default=sa.text("'{}'"),
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("settings", schema=None) as batch_op:
+        batch_op.drop_column("filing_checklist_state")

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -51,13 +51,29 @@ def _build_line_item_model(model_cls, item: dict):
 
 def _apply_line_tax_defaults(item: dict, settings: models.Settings):
     next_item = dict(item or {})
+    vat_enabled = bool(getattr(settings, "vat_registered", False))
     next_item.setdefault("tax_kind", "vat")
     next_item.setdefault("tax_code", settings.default_vat_code or "standard")
-    if next_item.get("tax_rate") is None:
+    if not vat_enabled:
+        next_item["tax_rate"] = 0
+        next_item["tax_inclusive"] = False
+    elif next_item.get("tax_rate") is None:
         next_item["tax_rate"] = float(settings.default_vat_rate or 0)
     next_item.setdefault("tax_inclusive", bool(settings.vat_inclusive_default))
     next_item.setdefault("tax_override", False)
     return next_item
+
+
+def _normalize_expense_tax_fields(data: dict, settings: models.Settings) -> dict:
+    next_data = dict(data or {})
+    if not bool(getattr(settings, "vat_registered", False)):
+        next_data["tax_rate"] = 0
+        next_data["tax_inclusive"] = False
+        next_data["tax_amount"] = 0
+        amount_value = _round_money(next_data.get("amount", 0))
+        next_data["net_amount"] = amount_value
+        next_data["gross_amount"] = amount_value
+    return next_data
 
 
 def _default_tax_rate_catalog_payload():
@@ -1408,6 +1424,8 @@ def restore_proposal_version(
 
 def create_expense(db: Session, client_id: int | None, payload: schemas.ExpenseCreate):
     data = payload.model_dump()
+    settings = get_or_create_settings(db)
+    data = _normalize_expense_tax_fields(data, settings)
     receipts = data.pop("receipts", None) or []
     display_id = (data.pop("display_id", None) or "").strip()
     is_legacy = data.pop("is_legacy", None)
@@ -1430,7 +1448,6 @@ def create_expense(db: Session, client_id: int | None, payload: schemas.ExpenseC
     ]
     db.commit()
     db.refresh(expense)
-    settings = get_or_create_settings(db)
     if not expense.display_id:
         if display_id:
             ensure_display_id_unique(db, models.Expense, display_id)
@@ -1446,6 +1463,30 @@ def create_expense(db: Session, client_id: int | None, payload: schemas.ExpenseC
 
 def update_expense(db: Session, expense: models.Expense, payload: schemas.ExpenseUpdate):
     data = payload.model_dump(exclude_unset=True)
+    settings = get_or_create_settings(db)
+    if any(
+        field in data
+        for field in ("amount", "net_amount", "tax_amount", "gross_amount", "tax_rate", "tax_inclusive")
+    ):
+        merged_for_normalization = {
+            "amount": data.get("amount", expense.amount),
+            "net_amount": data.get("net_amount", expense.net_amount),
+            "tax_amount": data.get("tax_amount", expense.tax_amount),
+            "gross_amount": data.get("gross_amount", expense.gross_amount),
+            "tax_rate": data.get("tax_rate", expense.tax_rate),
+            "tax_inclusive": data.get("tax_inclusive", expense.tax_inclusive),
+        }
+        normalized = _normalize_expense_tax_fields(merged_for_normalization, settings)
+        data.update(
+            {
+                "tax_rate": normalized.get("tax_rate"),
+                "tax_inclusive": normalized.get("tax_inclusive"),
+                "tax_amount": normalized.get("tax_amount"),
+                "net_amount": normalized.get("net_amount"),
+                "gross_amount": normalized.get("gross_amount"),
+                "amount": normalized.get("amount"),
+            }
+        )
     receipts = data.pop("receipts", None)
     if "display_id" in data:
         display_id = (data.pop("display_id") or "").strip()
@@ -1481,7 +1522,6 @@ def update_expense(db: Session, expense: models.Expense, payload: schemas.Expens
     db.commit()
     db.refresh(expense)
     if not expense.display_id:
-        settings = get_or_create_settings(db)
         expense.display_id = build_display_id(settings.expense_prefix or "EXP", expense.id)
         expense.is_legacy = False
         db.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timedelta, timezone
 from collections import defaultdict
+import csv
+import io
 import mimetypes
 from pathlib import Path
 import re
 import sqlite3
+import zipfile
 from uuid import uuid4
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, UploadFile, File, Form
@@ -37,7 +40,6 @@ from .db import (
 from .email_utils import generate_email_draft, send_email_smtp, test_smtp_connection
 from base64 import b64encode, b64decode
 from .security import password_meets_policy, verify_password
-from weasyprint import HTML
 
 
 app = FastAPI(
@@ -1174,73 +1176,238 @@ def filing_pack_summary(period: str = "all", db: Session = Depends(get_db), user
 @app.get("/tax/filing-pack/export")
 def filing_pack_export(
     period: str = "all",
-    format: str = "csv",
+    format: str = "zip",
     db: Session = Depends(get_db),
     user=Depends(require_user),
 ):
-    pack = crud.get_filing_pack(db, period=period)
-    filename_base = f"tax-filing-pack-{period}"
-    csv_rows = [
-        "section,key,value",
-        f"meta,mode,{pack['mode']}",
-        f"meta,basis,{pack['basis']}",
-        f"meta,period_start,{pack['period_start'] or ''}",
-        f"meta,period_end,{pack['period_end'] or ''}",
-        f"vat,output_vat,{pack['vat_summary']['output_vat']}",
-        f"vat,input_vat,{pack['vat_summary']['input_vat']}",
-        f"vat,credit_note_vat,{pack['vat_summary']['credit_note_vat']}",
-        f"vat,refund_vat,{pack['vat_summary']['refund_vat']}",
-        f"vat,net_vat_due,{pack['vat_summary']['net_vat_due']}",
-    ]
-    if pack["direct_tax_summary"].get("corporation"):
-        corp = pack["direct_tax_summary"]["corporation"]
-        csv_rows.extend([
-            f"direct_tax,estimated_profit,{corp['estimated_profit']}",
-            f"direct_tax,estimated_tax_due,{corp['estimated_tax_due']}",
-            f"direct_tax,rate,{corp['rate']}",
-        ])
-    if pack["direct_tax_summary"].get("sole_trader"):
-        sole = pack["direct_tax_summary"]["sole_trader"]
-        csv_rows.extend([
-            f"direct_tax,estimated_profit,{sole['estimated_profit']}",
-            f"direct_tax,taxable_profit,{sole['taxable_profit']}",
-            f"direct_tax,estimated_income_tax_due,{sole['estimated_income_tax_due']}",
-            f"direct_tax,estimated_class4_nic_due,{sole['estimated_class4_nic_due']}",
-        ])
+    normalized_period = crud._coerce_period(period)
+    if normalized_period == "all":
+        raise HTTPException(
+            status_code=400,
+            detail="Select a specific financial year before exporting the filing pack.",
+        )
+    if (format or "zip").strip().lower() not in {"zip"}:
+        raise HTTPException(status_code=400, detail="Only ZIP export is supported for filing pack.")
 
-    if format.lower() == "pdf":
-        html = f"""
-        <html><body style="font-family: sans-serif;">
-        <h1>Tax Filing Pack</h1>
-        <p><strong>Mode:</strong> {pack['mode']}</p>
-        <p><strong>Basis:</strong> {pack['basis']}</p>
-        <p><strong>Period:</strong> {pack['period_start'] or '—'} to {pack['period_end'] or '—'}</p>
-        <h2>VAT</h2>
-        <ul>
-          <li>Output VAT: {pack['vat_summary']['output_vat']}</li>
-          <li>Input VAT: {pack['vat_summary']['input_vat']}</li>
-          <li>Credit note VAT: {pack['vat_summary']['credit_note_vat']}</li>
-          <li>Refund VAT: {pack['vat_summary']['refund_vat']}</li>
-          <li>Net VAT due: {pack['vat_summary']['net_vat_due']}</li>
-        </ul>
-        <h2>Direct Tax</h2>
-        <pre>{pack['direct_tax_summary']}</pre>
-        <h2>Assumptions</h2>
-        <pre>{pack['assumptions']}</pre>
-        </body></html>
-        """
-        pdf_bytes = HTML(string=html).write_pdf()
-        return Response(
-            content=pdf_bytes,
-            media_type="application/pdf",
-            headers={"Content-Disposition": f'attachment; filename="{filename_base}.pdf"'},
+    settings_row = crud.get_or_create_settings(db)
+    period_start, period_end = crud._period_bounds(normalized_period, settings_row)
+    invoices = [
+        item
+        for item in db.query(models.Invoice).all()
+        if crud._in_period(item.issued_at, period_start, period_end)
+    ]
+    expenses = [
+        item
+        for item in db.query(models.Expense).all()
+        if crud._in_period(item.incurred_date, period_start, period_end)
+    ]
+
+    def _dt(value):
+        if not value:
+            return ""
+        return value.isoformat()
+
+    def _money(value):
+        return f"{float(value or 0):.2f}"
+
+    def _csv_bytes(headers: list[str], rows: list[list[str]]):
+        stream = io.StringIO()
+        writer = csv.writer(stream)
+        writer.writerow(headers)
+        writer.writerows(rows)
+        return stream.getvalue().encode("utf-8")
+
+    if period_start:
+        folder_name = f"FY{period_start.year}{str((period_start.year + 1) % 100).zfill(2)}"
+    else:
+        folder_name = normalized_period.replace("fy_", "FY")
+    root = f"{folder_name}/"
+
+    invoice_rows = []
+    line_item_rows = []
+    for invoice in sorted(invoices, key=lambda item: (item.issued_at or datetime.min, item.id)):
+        client = getattr(invoice, "client", None)
+        invoice_rows.append(
+            [
+                str(invoice.id),
+                invoice.display_id or "",
+                str(invoice.client_id or ""),
+                getattr(client, "company", None) or getattr(client, "name", None) or "",
+                invoice.title or "",
+                str(invoice.status or "").title(),
+                _dt(invoice.issued_at),
+                _dt(invoice.due_date),
+                _money(invoice.net_amount or invoice.amount),
+                _money(invoice.tax_amount),
+                _money(invoice.gross_amount or invoice.amount),
+                _money(invoice.amount),
+                invoice.notes or "",
+            ]
+        )
+        for line in invoice.line_items or []:
+            line_item_rows.append(
+                [
+                    str(invoice.id),
+                    invoice.display_id or "",
+                    str(line.id),
+                    line.description or "",
+                    str(float(line.quantity or 0)),
+                    _money(line.unit_amount),
+                    _money(line.net_amount),
+                    _money(line.tax_amount),
+                    _money(line.gross_amount),
+                    str(line.tax_code or ""),
+                    str(float(line.tax_rate or 0)),
+                    str(line.tax_kind or ""),
+                    "inclusive" if bool(line.tax_inclusive) else "exclusive",
+                ]
+            )
+
+    expense_rows = []
+    receipt_rows = []
+    receipt_binary_items: list[tuple[str, bytes]] = []
+    used_receipt_names: set[str] = set()
+    for expense in sorted(expenses, key=lambda item: (item.incurred_date or datetime.min, item.id)):
+        client = getattr(expense, "client", None)
+        expense_rows.append(
+            [
+                str(expense.id),
+                expense.display_id or "",
+                str(expense.client_id or ""),
+                getattr(client, "company", None) or getattr(client, "name", None) or "",
+                expense.title or "",
+                _dt(expense.incurred_date),
+                _money(expense.net_amount or expense.amount),
+                _money(expense.tax_amount),
+                _money(expense.gross_amount or expense.amount),
+                str(expense.tax_code or ""),
+                str(float(expense.tax_rate or 0)),
+                str(expense.tax_kind or ""),
+                "inclusive" if bool(expense.tax_inclusive) else "exclusive",
+                "yes" if bool(expense.vat_reclaimable) else "no",
+                expense.notes or "",
+            ]
+        )
+        for receipt in expense.receipts or []:
+            receipt_name = _next_unique_filename(
+                receipt.filename or Path(receipt.file_path or "").name or "receipt",
+                used_receipt_names,
+            )
+            receipt_rows.append(
+                [
+                    str(expense.id),
+                    expense.display_id or "",
+                    str(receipt.id),
+                    receipt.filename or "",
+                    receipt.file_path or "",
+                    f"receipts/{receipt_name}",
+                ]
+            )
+            payload = _load_upload_attachment(receipt.file_path or "")
+            if payload is not None:
+                receipt_binary_items.append((receipt_name, payload))
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(
+            f"{root}invoices/invoices.csv",
+            _csv_bytes(
+                [
+                    "id",
+                    "display_id",
+                    "client_id",
+                    "client_name",
+                    "title",
+                    "status",
+                    "issued_at",
+                    "due_date",
+                    "net_amount",
+                    "tax_amount",
+                    "gross_amount",
+                    "amount",
+                    "notes",
+                ],
+                invoice_rows,
+            ),
+        )
+        archive.writestr(
+            f"{root}invoices/invoice_line_items.csv",
+            _csv_bytes(
+                [
+                    "invoice_id",
+                    "invoice_display_id",
+                    "line_item_id",
+                    "description",
+                    "quantity",
+                    "unit_amount",
+                    "net_amount",
+                    "tax_amount",
+                    "gross_amount",
+                    "tax_code",
+                    "tax_rate",
+                    "tax_kind",
+                    "tax_mode",
+                ],
+                line_item_rows,
+            ),
+        )
+        archive.writestr(
+            f"{root}expenses/expenses.csv",
+            _csv_bytes(
+                [
+                    "id",
+                    "display_id",
+                    "client_id",
+                    "client_name",
+                    "title",
+                    "incurred_date",
+                    "net_amount",
+                    "tax_amount",
+                    "gross_amount",
+                    "tax_code",
+                    "tax_rate",
+                    "tax_kind",
+                    "tax_mode",
+                    "vat_reclaimable",
+                    "notes",
+                ],
+                expense_rows,
+            ),
+        )
+        archive.writestr(
+            f"{root}expenses/expense_receipts.csv",
+            _csv_bytes(
+                [
+                    "expense_id",
+                    "expense_display_id",
+                    "receipt_id",
+                    "filename",
+                    "file_path",
+                    "bundle_path",
+                ],
+                receipt_rows,
+            ),
+        )
+        archive.writestr(
+            f"{root}expenses/receipts/README.txt",
+            "Put expense receipt files in this folder if missing from export.",
+        )
+        for receipt_name, payload in receipt_binary_items:
+            archive.writestr(f"{root}expenses/receipts/{receipt_name}", payload)
+        archive.writestr(
+            f"{root}bank-statements/README.txt",
+            "Place bank statements for this filing period in this folder.",
+        )
+        archive.writestr(
+            f"{root}P60s/README.txt",
+            "Place payroll/P60 documents for this filing period in this folder.",
         )
 
-    csv_text = "\n".join(csv_rows)
+    zip_filename = f"tax-filing-pack-{folder_name}.zip"
     return Response(
-        content=csv_text.encode("utf-8"),
-        media_type="text/csv",
-        headers={"Content-Disposition": f'attachment; filename="{filename_base}.csv"'},
+        content=zip_buffer.getvalue(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{zip_filename}"'},
     )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -754,6 +754,7 @@ class Settings(WorkspaceScoped, Base):
     tax_policy_next_review_due: Mapped[datetime | None] = mapped_column(DateTime)
     tax_policy_review_notes: Mapped[str | None] = mapped_column(Text())
     other_taxes: Mapped[list[dict] | None] = mapped_column(JSON, default=list)
+    filing_checklist_state: Mapped[dict | None] = mapped_column(JSON, default=dict)
 
 
 class TaxRateCatalog(WorkspaceScoped, Base):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1073,6 +1073,7 @@ class SettingsBase(BaseModel):
     tax_policy_next_review_due: Optional[datetime] = None
     tax_policy_review_notes: Optional[str] = None
     other_taxes: list[dict] = []
+    filing_checklist_state: dict = Field(default_factory=dict)
 
 
 class SettingsOut(SettingsBase):
@@ -1143,3 +1144,4 @@ class SettingsUpdate(BaseModel):
     tax_policy_next_review_due: datetime | None = None
     tax_policy_review_notes: str | None = None
     other_taxes: list[dict] | None = None
+    filing_checklist_state: dict | None = None

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -244,7 +244,7 @@ const api = {
   getDirectTaxSummary: (period = "all") =>
     request(`/tax/direct-summary?period=${encodeURIComponent(period)}`),
   getFilingPack: (period = "all") => request(`/tax/filing-pack?period=${encodeURIComponent(period)}`),
-  downloadFilingPack: async ({ period = "all", format = "csv" } = {}) => {
+  downloadFilingPack: async ({ period = "all", format = "zip" } = {}) => {
     let response;
     try {
       response = await fetch(
@@ -262,7 +262,7 @@ const api = {
     }
     const disposition = response.headers.get("content-disposition") || "";
     const filenameMatch = disposition.match(/filename="?([^"]+)"?/);
-    const filename = filenameMatch ? filenameMatch[1] : `tax-filing-pack.${format}`;
+    const filename = filenameMatch ? filenameMatch[1] : `tax-filing-pack.${format || "zip"}`;
     const blob = await response.blob();
     return { blob, filename };
   },

--- a/frontend/src/constants/defaults.js
+++ b/frontend/src/constants/defaults.js
@@ -26,7 +26,7 @@ const emptyInvoice = {
       quantity: 1,
       unit_amount: "",
       tax_code: "standard",
-      tax_rate: 20,
+      tax_rate: 0,
       tax_kind: "vat",
       tax_inclusive: false,
       tax_override: false,
@@ -56,7 +56,7 @@ const emptyQuote = {
       quantity: 1,
       unit_amount: "",
       tax_code: "standard",
-      tax_rate: 20,
+      tax_rate: 0,
       tax_kind: "vat",
       tax_inclusive: false,
       tax_override: false,
@@ -116,7 +116,7 @@ const emptyExpense = {
   title: "",
   amount: "",
   tax_code: "standard",
-  tax_rate: 20,
+  tax_rate: 0,
   tax_kind: "vat",
   tax_inclusive: false,
   vat_reclaimable: false,
@@ -214,6 +214,7 @@ const defaultSettings = {
   tax_policy_next_review_due: null,
   tax_policy_review_notes: "",
   other_taxes: [],
+  filing_checklist_state: {},
 };
 
 export {

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -11,13 +11,13 @@ import { Button } from "@/components/ui/button";
 function SummaryStat({ label, value, tone = "default" }) {
   const toneClass =
     tone === "positive"
-      ? "text-emerald-600"
+      ? "text-emerald-600 dark:text-emerald-400"
       : tone === "negative"
-        ? "text-rose-600"
+        ? "text-rose-600 dark:text-rose-400"
         : "text-foreground";
 
   return (
-    <div className="flex min-w-0 flex-col gap-1 rounded-2xl bg-slate-50/90 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+    <div className="flex min-w-0 flex-col gap-1 rounded-2xl border border-border/50 bg-muted/40 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
       <span className="text-sm text-muted-foreground">{label}</span>
       <span className={`text-sm font-semibold leading-tight ${toneClass}`}>{value}</span>
     </div>
@@ -30,7 +30,7 @@ function SummaryActionStat({ label, value, onClick }) {
       type="button"
       onClick={onClick}
       aria-label={`Open ${label.toLowerCase()}`}
-      className="flex w-full items-center justify-between rounded-2xl bg-slate-50/90 px-4 py-3 text-left transition-colors hover:bg-slate-100/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      className="flex w-full items-center justify-between rounded-2xl border border-border/50 bg-muted/40 px-4 py-3 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
     >
       <span className="text-sm text-muted-foreground">{label}</span>
       <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-foreground">
@@ -43,7 +43,7 @@ function SummaryActionStat({ label, value, onClick }) {
 
 function MetricTile({ label, value, description, className = "" }) {
   return (
-    <div className={`min-w-0 rounded-3xl bg-white/88 p-4 ${className}`}>
+    <div className={`min-w-0 rounded-3xl border border-border/50 bg-card p-4 ${className}`}>
       <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
         {label}
       </p>
@@ -59,8 +59,8 @@ function ReminderItem({ icon, label, value }) {
   const IconComponent = icon;
 
   return (
-    <div className="flex items-start gap-3 rounded-2xl bg-slate-50/85 px-4 py-4">
-      <div className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-700">
+    <div className="flex items-start gap-3 rounded-2xl border border-border/50 bg-muted/40 px-4 py-4">
+      <div className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted text-foreground">
         <IconComponent className="h-4 w-4" />
       </div>
       <div className="space-y-1">
@@ -75,11 +75,11 @@ function ReminderItem({ icon, label, value }) {
 
 function ProgressBand({ label, value, amount, tint = "slate" }) {
   const width = Math.max(8, Math.min(100, value));
-  const bandStyles = {
-    slate: "#0f172a",
-    blue: "#2563eb",
-    emerald: "#059669",
-    amber: "#d97706",
+  const bandClass = {
+    slate: "bg-foreground/85",
+    blue: "bg-blue-600 dark:bg-blue-500",
+    emerald: "bg-emerald-600 dark:bg-emerald-500",
+    amber: "bg-amber-600 dark:bg-amber-500",
   };
 
   return (
@@ -88,10 +88,10 @@ function ProgressBand({ label, value, amount, tint = "slate" }) {
         <span className="text-sm font-medium text-foreground">{label}</span>
         <span className="text-sm text-muted-foreground">{amount}</span>
       </div>
-      <div className="h-2 overflow-hidden rounded-full bg-slate-100 ">
+      <div className="h-2 overflow-hidden rounded-full bg-muted">
         <div
-          className="h-full rounded-full"
-          style={{ width: `${width}%`, backgroundColor: bandStyles[tint] }}
+          className={`h-full rounded-full ${bandClass[tint] || bandClass.slate}`}
+          style={{ width: `${width}%` }}
         />
       </div>
     </div>
@@ -100,14 +100,14 @@ function ProgressBand({ label, value, amount, tint = "slate" }) {
 
 function AdjustmentTile({ label, value, detail, tone = "slate" }) {
   const toneStyles = {
-    slate: "bg-slate-50 text-slate-700",
-    amber: "bg-amber-50 text-amber-700",
-    blue: "bg-blue-50 text-blue-700",
-    emerald: "bg-emerald-50 text-emerald-700",
+    slate: "bg-muted text-muted-foreground",
+    amber: "bg-amber-100 text-amber-800 dark:bg-amber-950/40 dark:text-amber-300",
+    blue: "bg-blue-100 text-blue-800 dark:bg-blue-950/40 dark:text-blue-300",
+    emerald: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
   };
 
   return (
-    <div className="rounded-2xl bg-white/90 p-4">
+    <div className="rounded-2xl border border-border/50 bg-card p-4">
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-1">
           <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
@@ -153,12 +153,12 @@ export default function DashboardPage({
   return (
     <section className="space-y-5">
       <div className="space-y-6">
-        <Card className="overflow-hidden rounded-[28px] border-border/60 bg-[linear-gradient(135deg,rgba(15,23,42,0.04),rgba(255,255,255,0.96),rgba(14,165,233,0.06))] shadow-sm">
+        <Card className="overflow-hidden rounded-[28px] border-border/60 bg-card shadow-sm">
           <CardContent className="p-5 lg:p-6">
           <div className="space-y-5">
             <div className="space-y-6">
                 <div className="space-y-4">
-                  <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/85 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-600 shadow-sm">
+                  <div className="inline-flex items-center gap-2 rounded-full border border-border bg-muted/40 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-foreground shadow-sm">
                     <Sparkles className="h-3.5 w-3.5" />
                     Client Management App
                   </div>
@@ -193,7 +193,7 @@ export default function DashboardPage({
                 </div>
               </div>
 
-            <div className="rounded-[28px] bg-white/90 p-5 backdrop-blur lg:p-6">
+            <div className="rounded-[28px] border border-border/50 bg-background/70 p-5 backdrop-blur lg:p-6">
               <div className="space-y-2">
                 <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
                   Financial posture
@@ -208,14 +208,14 @@ export default function DashboardPage({
                 </div>
 
               <div className="mt-5 grid gap-4 xl:grid-cols-[1.15fr_0.85fr]">
-                  <div className="space-y-4 rounded-3xl bg-slate-50/90 p-5">
+                  <div className="space-y-4 rounded-3xl border border-border/50 bg-muted/35 p-5">
                     <div className="grid gap-3 lg:grid-cols-2">
                       <SummaryStat label="Gross billing" value={formatGBP(grossBilling)} />
                       <SummaryStat label="Net collected" value={formatGBP(totalPaid)} tone="positive" />
                       <SummaryStat label="Invoice base" value={formatGBP(totalInvoiced)} />
                       <SummaryStat label="Gross-to-net gap" value={formatGBP(grossDelta)} tone="negative" />
                     </div>
-                    <div className="rounded-2xl bg-white/90 p-4">
+                    <div className="rounded-2xl border border-border/50 bg-card p-4">
                       <ProgressBand
                         label="Collection rate"
                         value={collectedRatio}
@@ -275,7 +275,7 @@ export default function DashboardPage({
             <CardTitle className="text-2xl">Workspace load</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4 px-6 pb-6 pt-4">
-            <div className="rounded-3xl bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(248,250,252,0.98))] p-5">
+            <div className="rounded-3xl border border-border/50 bg-muted/35 p-5">
               <div>
                 <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
                   Active portfolio

--- a/frontend/src/pages/InvoicesPage.jsx
+++ b/frontend/src/pages/InvoicesPage.jsx
@@ -233,7 +233,11 @@ export default function InvoicesPage({
                             unit_amount: item.unit_amount,
                             tax_kind: item.tax_kind || "vat",
                             tax_code: item.tax_code || "standard",
-                            tax_rate: item.tax_rate ?? 20,
+                            tax_rate:
+                              item.tax_rate ??
+                              (settings?.vat_registered
+                                ? settings?.default_vat_rate ?? 20
+                                : 0),
                             tax_inclusive: item.tax_inclusive === true,
                             tax_override: item.tax_override === true,
                           }))

--- a/frontend/src/pages/TaxPage.jsx
+++ b/frontend/src/pages/TaxPage.jsx
@@ -8,7 +8,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Combobox } from "@/components/ui/combobox";
-import { DataTable } from "@/components/data-table";
 import {
   Dialog,
   DialogContent,
@@ -21,6 +20,15 @@ import {
 import { api } from "@/api/client";
 import { formatDateTime, formatGBP } from "@/utils/format";
 import { fieldClass, labelClass } from "@/ui/formStyles";
+
+const FILING_CHECKLIST_ITEMS = [
+  { id: "export_data", label: "Export filing bundle" },
+  { id: "gather_bank_statements", label: "Gather bank statements" },
+  { id: "gather_p60s", label: "Gather P60s / payroll documents" },
+  { id: "share_with_accountant", label: "Share pack with accountant / prepare HMRC filing" },
+  { id: "submit_filing", label: "Submit filing" },
+  { id: "record_reference", label: "Record confirmation/reference" },
+];
 
 export default function TaxPage({
   settings,
@@ -35,10 +43,21 @@ export default function TaxPage({
   const [filingPack, setFilingPack] = useState(null);
   const [ratesCatalog, setRatesCatalog] = useState(null);
   const [ratesLoading, setRatesLoading] = useState(false);
+  const [checklistSaving, setChecklistSaving] = useState(false);
   const lastErrorToastRef = useRef({ message: "", at: 0 });
   const period = useMemo(
     () => (selectedYear === "all" ? "all" : `fy_${selectedYear}`),
     [selectedYear]
+  );
+  const isSpecificFinancialYear = selectedYear !== "all";
+  const filingChecklistState = settings?.filing_checklist_state || {};
+  const activeChecklist = useMemo(() => {
+    if (!isSpecificFinancialYear) return {};
+    return filingChecklistState[period] || {};
+  }, [filingChecklistState, isSpecificFinancialYear, period]);
+  const checklistCompletedCount = useMemo(
+    () => FILING_CHECKLIST_ITEMS.filter((item) => activeChecklist[item.id] === true).length,
+    [activeChecklist]
   );
   const vatEnabled = Boolean(settings?.vat_registered);
 
@@ -101,37 +120,62 @@ export default function TaxPage({
     }
   }, [ratesCatalog]);
 
-  const vatRateColumns = useMemo(
-    () => [
-      { accessorKey: "code", header: "Code" },
-      { accessorKey: "label", header: "Label" },
-      {
-        accessorKey: "rate",
-        header: "Rate %",
-        cell: ({ row }) => `${Number(row.original.rate || 0).toFixed(2)}%`,
-      },
-      {
-        accessorKey: "reclaimable",
-        header: "Reclaimable",
-        cell: ({ row }) => (
-          <Badge variant={row.original.reclaimable ? "secondary" : "outline"}>
-            {row.original.reclaimable ? "Yes" : "No"}
-          </Badge>
-        ),
-      },
-    ],
-    []
+  const saveChecklistState = useCallback(
+    async (nextChecklistState, errorMessage = "Unable to save checklist.") => {
+      const previous = settings?.filing_checklist_state || {};
+      updateSettings({ filing_checklist_state: nextChecklistState });
+      try {
+        setChecklistSaving(true);
+        await api.saveSettings({ filing_checklist_state: nextChecklistState });
+      } catch (error) {
+        updateSettings({ filing_checklist_state: previous });
+        toast.error(error?.message || errorMessage);
+      } finally {
+        setChecklistSaving(false);
+      }
+    },
+    [settings?.filing_checklist_state, updateSettings]
   );
 
-  const downloadPack = async (format) => {
+  const toggleChecklistItem = useCallback(
+    async (itemId, checked) => {
+      if (!isSpecificFinancialYear) return;
+      const nextChecklistState = {
+        ...(settings?.filing_checklist_state || {}),
+        [period]: {
+          ...((settings?.filing_checklist_state || {})[period] || {}),
+          [itemId]: checked === true,
+        },
+      };
+      await saveChecklistState(nextChecklistState);
+    },
+    [isSpecificFinancialYear, period, saveChecklistState, settings?.filing_checklist_state]
+  );
+
+  const downloadPack = async () => {
+    if (!isSpecificFinancialYear) {
+      toast.error("Select a specific financial year before exporting.");
+      return;
+    }
     try {
-      const { blob, filename } = await api.downloadFilingPack({ period, format });
+      const { blob, filename } = await api.downloadFilingPack({ period, format: "zip" });
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
       link.download = filename;
       link.click();
       URL.revokeObjectURL(url);
+      const existing = (settings?.filing_checklist_state || {})[period] || {};
+      if (!existing.export_data) {
+        const nextChecklistState = {
+          ...(settings?.filing_checklist_state || {}),
+          [period]: {
+            ...existing,
+            export_data: true,
+          },
+        };
+        await saveChecklistState(nextChecklistState, "Filing bundle exported, but checklist was not saved.");
+      }
     } catch (error) {
       toast.error(error.message || "Unable to export filing pack.");
     }
@@ -293,6 +337,10 @@ export default function TaxPage({
           <CardHeader>
             <CardTitle>VAT summary</CardTitle>
             <CardDescription>Accrual/cash VAT due estimates by selected period.</CardDescription>
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+              Estimates are guidance only. This app does not replace an accountant, and VAT liabilities
+              must be confirmed before filing.
+            </div>
           </CardHeader>
           <CardContent className="grid gap-4 md:grid-cols-3">
             <div className={fieldClass}>
@@ -330,6 +378,10 @@ export default function TaxPage({
             <CardDescription>
               Mode: {settings?.business_tax_mode === "sole_trader" ? "Sole trader" : "Limited company"}.
             </CardDescription>
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+              Figures are planning suggestions only, not final liabilities. Confirm tax with a qualified
+              accountant before submitting to HMRC.
+            </div>
           </CardHeader>
           <CardContent className="space-y-4">
             {directSummary?.corporation ? (
@@ -485,27 +537,56 @@ export default function TaxPage({
         <Card>
           <CardHeader>
             <CardTitle>Filing pack</CardTitle>
-            <CardDescription>Accountant-ready summary and exports for the selected period.</CardDescription>
+            <CardDescription>Export a structured FY handoff bundle and track filing completion.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="flex flex-wrap items-center gap-2">
-              <Button type="button" variant="outline" onClick={() => downloadPack("csv")}>
-                Export CSV
+              <Button
+                type="button"
+                variant="outline"
+                onClick={downloadPack}
+                disabled={!isSpecificFinancialYear}
+              >
+                Export filing bundle (ZIP)
               </Button>
-              <Button type="button" variant="outline" onClick={() => downloadPack("pdf")}>
-                Export PDF
-              </Button>
+              {!isSpecificFinancialYear ? (
+                <span className="text-xs text-muted-foreground">
+                  Select a specific FY in the sidebar to enable export.
+                </span>
+              ) : null}
+            </div>
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+              This app supports admin preparation only. It does not replace accountant advice or guarantee
+              final HMRC payable amounts.
+            </div>
+            <div className="rounded-md border p-3">
+              <div className="mb-3 flex items-center justify-between">
+                <p className="text-sm font-medium">Filing checklist</p>
+                <Badge variant="outline">
+                  {checklistCompletedCount}/{FILING_CHECKLIST_ITEMS.length} complete
+                </Badge>
+              </div>
+              <div className="space-y-2">
+                {FILING_CHECKLIST_ITEMS.map((item) => (
+                  <label
+                    key={item.id}
+                    className="flex min-h-9 items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm"
+                  >
+                    <span>{item.label}</span>
+                    <Checkbox
+                      checked={activeChecklist[item.id] === true}
+                      disabled={!isSpecificFinancialYear || checklistSaving}
+                      onCheckedChange={(value) => toggleChecklistItem(item.id, value === true)}
+                    />
+                  </label>
+                ))}
+              </div>
             </div>
             <div className="rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
               Generated {formatDateTime(filingPack?.assumptions?.generated_at)} ·{" "}
               {filingPack?.assumptions?.source_label || "HMRC guidance"} ·{" "}
               {filingPack?.assumptions?.version_label || "baseline"}
             </div>
-            <DataTable
-              columns={vatRateColumns}
-              data={ratesCatalog?.vat_rates || []}
-              emptyMessage="No VAT rates configured."
-            />
           </CardContent>
         </Card>
       ) : null}


### PR DESCRIPTION
## Summary
- Refreshed Tax Filing Pack for accountant handoff with a ZIP-first FY bundle export.
- Added persisted filing checklist state per workspace + financial year.
- Removed Filing Pack PDF export and improved tax disclaimers across VAT/Direct Tax/Filing tabs.
- Fixed VAT-disabled behavior so invoice/expense totals do not auto-add tax.
- Improved Dashboard dark-mode theming by replacing clashing hardcoded light colors with theme tokens.

## Changes

### Tax Filing Pack Export
- Reworked `GET /tax/filing-pack/export` to ZIP-only output.
- Export now requires a specific FY (`fy_YYYY`); `all` returns a clear `400`.
- ZIP structure now includes:
  - `FY{startYear}{endYearShort}/invoices/invoices.csv`
  - `FY.../invoices/invoice_line_items.csv`
  - `FY.../expenses/expenses.csv`
  - `FY.../expenses/expense_receipts.csv`
  - `FY.../expenses/receipts/<receipt files>`
  - `FY.../bank-statements/README.txt`
  - `FY.../P60s/README.txt`

### Filing Checklist Persistence
- Added `filing_checklist_state` to workspace settings (JSON), keyed by FY period.
- Added checklist UI in Tax > Filing Pack using shadcn checkboxes.
- Added completion progress indicator (`x/6 complete`).
- Exporting filing bundle auto-checks “Export filing bundle”.

### Tax UX and Messaging
- Removed Filing Pack PDF export action from UI.
- Added stronger visible notices that VAT/direct tax figures are planning guidance and not accountant replacement or filing directives.

### VAT Disabled Guardrails
- Backend now forces tax to zero when `vat_registered = false`:
  - Line item tax defaults normalized to `tax_rate=0`, `tax_inclusive=false`.
  - Expense tax fields normalized similarly.
- Frontend defaults now start with `tax_rate=0` for invoice/quote/expense line inputs.
- Invoice quote->line-item mapping no longer falls back to 20% in VAT-disabled workspaces.

### Dashboard Dark Mode
- Replaced hardcoded `slate/white` backgrounds and fixed color values with semantic theme tokens:
  - `bg-card`, `bg-background`, `bg-muted`, `border-border`, `text-foreground`, `text-muted-foreground`
- Updated value tones/pills/progress bars to remain readable in dark mode.

## Migration
- Added Alembic migration:
  - `d4a9f8b1c2e3_add_filing_checklist_state_to_settings.py`
- Run:
  - `alembic upgrade head`

## Validation
- Backend syntax check passed (`python -m py_compile ...`).
- Frontend build passed (`npm run build`).

## Notes
- Existing tax summaries and period behavior remain intact.
- Filing Pack table of VAT rate catalog in the tab was removed as requested.
